### PR TITLE
ATS-434 : Implement `/transform/config` endpoint in T-Engines

### DIFF
--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -108,7 +108,7 @@ public abstract class AbstractTransformerController implements TransformControll
     @Autowired
     private ObjectMapper objectMapper;
 
-    @GetMapping(value = "/tconfig")
+    @GetMapping(value = "/transform/config")
     public ResponseEntity<TransformConfig> info()
     {
         logger.info("GET Transform Config.");

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -108,7 +108,7 @@ public abstract class AbstractTransformerController implements TransformControll
     @Autowired
     private ObjectMapper objectMapper;
 
-    @GetMapping(value = "/info")
+    @GetMapping(value = "/tconfig")
     public ResponseEntity<TransformConfig> info()
     {
         logger.info("GET Transform Config.");

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -34,6 +34,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -114,7 +115,7 @@ public abstract class AbstractTransformerController implements TransformControll
         try
         {
             ClassPathResource classPathResource = new ClassPathResource(ENGINE_CONFIG);
-            File engineConfigFile = classPathResource.getFile();
+            InputStream engineConfigFile = classPathResource.getInputStream();
 
             TransformConfig transformConfig = objectMapper.setSerializationInclusion(NON_NULL)
                 .readValue(engineConfigFile, TransformConfig.class);

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractTransformerControllerTest.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractTransformerControllerTest.java
@@ -312,7 +312,7 @@ public abstract class AbstractTransformerControllerTest
         ReflectionTestUtils
             .setField(AbstractTransformerController.class, "ENGINE_CONFIG", "engine_config.json");
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tconfig"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/transform/config"))
             .andExpect(status().is(OK.value())).andExpect(
                 header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andReturn().getResponse().getContentAsString();
@@ -330,7 +330,7 @@ public abstract class AbstractTransformerControllerTest
         ReflectionTestUtils.setField(AbstractTransformerController.class, "ENGINE_CONFIG",
             "engine_config_with_duplicates.json");
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tconfig"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/transform/config"))
             .andExpect(status().is(OK.value())).andExpect(
                 header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andReturn().getResponse().getContentAsString();
@@ -357,7 +357,7 @@ public abstract class AbstractTransformerControllerTest
         ReflectionTestUtils.setField(AbstractTransformerController.class, "ENGINE_CONFIG",
             "engine_config_incomplete.json");
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tconfig"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/transform/config"))
             .andExpect(status().is(OK.value())).andExpect(
                 header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andReturn().getResponse().getContentAsString();
@@ -379,7 +379,7 @@ public abstract class AbstractTransformerControllerTest
         ReflectionTestUtils.setField(AbstractTransformerController.class, "ENGINE_CONFIG",
             "engine_config_no_transform_options.json");
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tconfig"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/transform/config"))
             .andExpect(status().is(OK.value())).andExpect(
                 header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andReturn().getResponse().getContentAsString();

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractTransformerControllerTest.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractTransformerControllerTest.java
@@ -312,7 +312,7 @@ public abstract class AbstractTransformerControllerTest
         ReflectionTestUtils
             .setField(AbstractTransformerController.class, "ENGINE_CONFIG", "engine_config.json");
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/info"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tconfig"))
             .andExpect(status().is(OK.value())).andExpect(
                 header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andReturn().getResponse().getContentAsString();
@@ -330,7 +330,7 @@ public abstract class AbstractTransformerControllerTest
         ReflectionTestUtils.setField(AbstractTransformerController.class, "ENGINE_CONFIG",
             "engine_config_with_duplicates.json");
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/info"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tconfig"))
             .andExpect(status().is(OK.value())).andExpect(
                 header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andReturn().getResponse().getContentAsString();
@@ -357,7 +357,7 @@ public abstract class AbstractTransformerControllerTest
         ReflectionTestUtils.setField(AbstractTransformerController.class, "ENGINE_CONFIG",
             "engine_config_incomplete.json");
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/info"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tconfig"))
             .andExpect(status().is(OK.value())).andExpect(
                 header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andReturn().getResponse().getContentAsString();
@@ -379,7 +379,7 @@ public abstract class AbstractTransformerControllerTest
         ReflectionTestUtils.setField(AbstractTransformerController.class, "ENGINE_CONFIG",
             "engine_config_no_transform_options.json");
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/info"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/tconfig"))
             .andExpect(status().is(OK.value())).andExpect(
                 header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andReturn().getResponse().getContentAsString();


### PR DESCRIPTION
   - rename endpoint since '/info' is already used by Spring Boot
   - fix config file loading