### PR TITLE
ATS-481: temp workaround for transitive dependency

### DIFF
--- a/alfresco-docker-alfresco-pdf-renderer/pom.xml
+++ b/alfresco-docker-alfresco-pdf-renderer/pom.xml
@@ -45,10 +45,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-core</artifactId>
+            <!--
+            TODO temp workaround for ATS-481 / REPO-4514 (exclude: dom4j.dom4j 1.6.1 / include org.dom4j.dom4j 2.1.1)
+            TODO remove this workaround once transitive dependencies have been fixed (surf-core-configservice -> alfresco-core)
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+        
     </dependencies>
 
     <build>

--- a/alfresco-docker-imagemagick/pom.xml
+++ b/alfresco-docker-imagemagick/pom.xml
@@ -45,10 +45,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-core</artifactId>
+            <!--
+            TODO temp workaround for ATS-481 / REPO-4514 (exclude: dom4j.dom4j 1.6.1 / include org.dom4j.dom4j 2.1.1)
+            TODO remove this workaround once transitive dependencies have been fixed (surf-core-configservice -> alfresco-core)
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/alfresco-docker-libreoffice/pom.xml
+++ b/alfresco-docker-libreoffice/pom.xml
@@ -45,10 +45,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-core</artifactId>
+            <!--
+            TODO temp workaround for ATS-481 / REPO-4514 (exclude: dom4j.dom4j 1.6.1 / include org.dom4j.dom4j 2.1.1)
+            TODO remove this workaround once transitive dependencies have been fixed (surf-core-configservice -> alfresco-core)
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-jodconverter-core</artifactId>

--- a/alfresco-docker-tika/pom.xml
+++ b/alfresco-docker-tika/pom.xml
@@ -46,10 +46,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-core</artifactId>
+            <!--
+            TODO temp workaround for ATS-481 / REPO-4514 (exclude: dom4j.dom4j 1.6.1 / include org.dom4j.dom4j 2.1.1)
+            TODO remove this workaround once transitive dependencies have been fixed (surf-core-configservice -> alfresco-core)
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-data-model</artifactId>

--- a/alfresco-docker-transform-misc/pom.xml
+++ b/alfresco-docker-transform-misc/pom.xml
@@ -47,9 +47,25 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-core</artifactId>
+            <!--
+            TODO temp workaround for ATS-481 / REPO-4514 (exclude: dom4j.dom4j 1.6.1 / include org.dom4j.dom4j 2.1.1)
+            TODO remove this workaround once transitive dependencies have been fixed (surf-core-configservice -> alfresco-core)
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.1.1</version>
         </dependency>
 
         <!-- HtmlParserContentTransformer -->

--- a/alfresco-transformer-base/pom.xml
+++ b/alfresco-transformer-base/pom.xml
@@ -39,10 +39,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-core</artifactId>
+            <!--
+            TODO temp workaround for ATS-481 / REPO-4514 (exclude: dom4j.dom4j 1.6.1 / include org.dom4j.dom4j 2.1.1)
+            TODO remove this workaround once transitive dependencies have been fixed (surf-core-configservice -> alfresco-core)
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-transform-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,12 @@
                 <artifactId>alfresco-core</artifactId>
                 <version>${dependency.alfresco-core.version}</version>
                 <!--
-                TODO temp workaround for ATS-481 / REPO-4514
+                TODO temp workaround for ATS-481 / REPO-4514 (exclude: dom4j.dom4j 1.6.1 / include org.dom4j.dom4j 2.1.1)
                 TODO remove this workaround once transitive dependencies have been fixed (surf-core-configservice -> alfresco-core)
                 -->
                 <exclusions>
                     <exclusion>
-                        <groupId>org</groupId>
+                        <groupId>dom4j</groupId>
                         <artifactId>dom4j</artifactId>
                     </exclusion>
                 </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,29 @@
     </scm>
 
     <dependencyManagement>
+
         <dependencies>
             <dependency>
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-core</artifactId>
                 <version>${dependency.alfresco-core.version}</version>
+                <!--
+                TODO temp workaround for ATS-481 / REPO-4514
+                TODO remove this workaround once transitive dependencies have been fixed (surf-core-configservice -> alfresco-core)
+                -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>org</groupId>
+                        <artifactId>dom4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.dom4j</groupId>
+                <artifactId>dom4j</artifactId>
+                <version>2.1.1</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-data-model</artifactId>


### PR DESCRIPTION
- temp workaround attempt to update from dom4j 1.6.1 to 2.1.1
- transitive dependency (alfresco-core <- spring-surf-core-configservice)
- workaround should be removed once REPO-4514 resolved (future alfresco-core <- spring-surf)
