### PR TITLE
ATS-534 : Security - Vulnerability in Quartz - CVE-2019-13990

### DIFF
--- a/_ci/build.sh
+++ b/_ci/build.sh
@@ -8,8 +8,11 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/../"
 # Always build the image, but only publish from the "master" branch
 [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] && PROFILE="internal" || PROFILE="local"
 
+# If the branch is "master" and the commit is not a Pull Request then deploy the JAR SNAPSHOT artifacts
+[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] && DEPLOY="deploy" || DEPLOY="install"
+
 mvn -B -U \
-    clean install \
+    clean ${DEPLOY} \
     -DadditionalOption=-Xdoclint:none -Dmaven.javadoc.skip=true \
     "-P${PROFILE},docker-it-setup"
 

--- a/alfresco-docker-tika/pom.xml
+++ b/alfresco-docker-tika/pom.xml
@@ -75,6 +75,11 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcmail-jdk15on</artifactId>
                 </exclusion>
+                <!-- TODO ATS-534 check transformations not affected by this missing quartz lib -->
+                <exclusion>
+                    <groupId>org.quartz-scheduler</groupId>
+                    <artifactId>quartz</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency.pdfbox.version>2.0.16</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.1</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
-        <dependency.alfresco-transform-model.version>1.0.2.3</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.0.2.6</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.15.9</dependency.activemq.version>
         <dependency.jackson.version>2.9.9</dependency.jackson.version>
         <dependency.jackson-databind.version>2.9.9.2</dependency.jackson-databind.version>


### PR DESCRIPTION
- publish SNAPSHOT artifacts from the master branch
- exclude quartz dependency from tika-parsers