### PR TITLE
WIP: Fix/repo 4639 content conversion tika

### DIFF
--- a/alfresco-docker-tika/src/main/java/org/alfresco/transformer/TikaController.java
+++ b/alfresco-docker-tika/src/main/java/org/alfresco/transformer/TikaController.java
@@ -26,6 +26,24 @@
  */
 package org.alfresco.transformer;
 
+import org.alfresco.transform.exceptions.TransformException;
+import org.alfresco.transformer.executors.TikaJavaExecutor;
+import org.alfresco.transformer.logging.LogEntry;
+import org.alfresco.transformer.probes.ProbeTestTransform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.util.Map;
+
 import static org.alfresco.transformer.executors.Tika.INCLUDE_CONTENTS;
 import static org.alfresco.transformer.executors.Tika.NOT_EXTRACT_BOOKMARKS_TEXT;
 import static org.alfresco.transformer.executors.Tika.PDF_BOX;
@@ -41,25 +59,6 @@ import static org.alfresco.transformer.util.Util.stringToBoolean;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
-
-import java.io.File;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.alfresco.transform.exceptions.TransformException;
-import org.alfresco.transformer.executors.TikaJavaExecutor;
-import org.alfresco.transformer.logging.LogEntry;
-import org.alfresco.transformer.probes.ProbeTestTransform;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.Resource;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 
 /**
  * Controller for the Docker based Tika transformers.
@@ -122,6 +121,7 @@ public class TikaController extends AbstractTransformerController
     @PostMapping(value = "/transform", consumes = MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Resource> transform(HttpServletRequest request,
         @RequestParam("file") MultipartFile sourceMultipartFile,
+        @RequestParam("sourceMimetype") String sourceMimetype,
         @RequestParam("targetExtension") String targetExtension,
         @RequestParam("targetMimetype") String targetMimetype,
         @RequestParam("targetEncoding") String targetEncoding,
@@ -129,15 +129,9 @@ public class TikaController extends AbstractTransformerController
         @RequestParam(value = "timeout", required = false) Long timeout,
         @RequestParam(value = "testDelay", required = false) Long testDelay,
 
-        @RequestParam(value = "transform") String transform,
         @RequestParam(value = "includeContents", required = false) Boolean includeContents,
         @RequestParam(value = "notExtractBookmarksText", required = false) Boolean notExtractBookmarksText)
     {
-        if (!TRANSFORM_NAMES.contains(transform))
-        {
-            throw new TransformException(BAD_REQUEST.value(), "Invalid transform value");
-        }
-
         String targetFilename = createTargetFileName(sourceMultipartFile.getOriginalFilename(),
             targetExtension);
         getProbeTestTransform().incrementTransformerCount();
@@ -148,6 +142,11 @@ public class TikaController extends AbstractTransformerController
         // TODO Consider streaming the request and response rather than using temporary files
         // https://www.logicbig.com/tutorials/spring-framework/spring-web-mvc/streaming-response-body.html
 
+        Map<String, String> transformOptions = createTransformOptions(
+                "includeContents", includeContents,
+                "notExtractBookmarksText", notExtractBookmarksText,
+                "targetEncoding", targetEncoding);
+        String transform = getTransformerName(sourceFile, sourceMimetype, targetMimetype, transformOptions);
         javaExecutor.call(sourceFile, targetFile, transform,
             includeContents != null && includeContents ? INCLUDE_CONTENTS : null,
             notExtractBookmarksText != null && notExtractBookmarksText ? NOT_EXTRACT_BOOKMARKS_TEXT : null,
@@ -169,11 +168,11 @@ public class TikaController extends AbstractTransformerController
         logger.debug("Processing request with: sourceFile '{}', targetFile '{}', transformOptions" +
                      " '{}', timeout {} ms", sourceFile, targetFile, transformOptions, timeout);
 
-        final String transform = transformOptions.get("transform");
         final Boolean includeContents = stringToBoolean("includeContents");
         final Boolean notExtractBookmarksText = stringToBoolean("notExtractBookmarksText");
         final String targetEncoding = transformOptions.get("targetEncoding");
 
+        String transform = getTransformerName(sourceFile, sourceMimetype, targetMimetype, transformOptions);
         javaExecutor.call(sourceFile, targetFile, transform,
             includeContents != null && includeContents ? INCLUDE_CONTENTS : null,
             notExtractBookmarksText != null && notExtractBookmarksText ? NOT_EXTRACT_BOOKMARKS_TEXT : null,

--- a/alfresco-docker-tika/src/main/resources/engine_config.json
+++ b/alfresco-docker-tika/src/main/resources/engine_config.json
@@ -1,16 +1,16 @@
 {
   "transformOptions": {
     "tikaOptions": [
-      {"value": {"name": "transform"}},
+      {"value": {"required":true, "name": "transform" }},
       {"value": {"name": "includeContents"}},
       {"value": {"name": "notExtractBookmarksText"}},
-      {"value": {"name": "targetMimetype"}},
-      {"value": {"name": "targetEncoding"}}
+      {"value": {"required":true, "name": "targetMimetype"}},
+      {"value": {"required":true, "name": "targetEncoding"}}
     ]
   },
   "transformers": [
     {
-      "transformerName": "tika",
+      "transformerName": "archive",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/html"},
         {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/plain"},
@@ -30,7 +30,201 @@
         {"sourceMediaType": "application/zip",                                                             "targetMediaType": "text/html"},
         {"sourceMediaType": "application/zip",                                                             "targetMediaType": "text/plain"},
         {"sourceMediaType": "application/zip",                                                             "targetMediaType": "application/xhtml+xml"},
-        {"sourceMediaType": "application/zip",                                                             "targetMediaType": "text/xml"},
+        {"sourceMediaType": "application/zip",                                                             "targetMediaType": "text/xml"}
+      ],
+      "transformOptions": [
+        "tikaOptions"
+      ]
+    },
+    {
+      "transformerName": "outlookMsg",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/xml"}
+      ],
+      "transformOptions": [
+        "tikaOptions"
+      ]
+    },
+    {
+      "transformerName": "pdfbox",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/pdf",                                                             "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/pdf",                             "maxSourceSizeBytes": 26214400, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/pdf",                                                             "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/pdf",                                                             "targetMediaType": "text/xml"}
+      ],
+      "transformOptions": [
+        "tikaOptions"
+      ]
+    },
+    {
+      "transformerName": "office",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/msword",                                                          "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-project",                                                  "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-project",                                                  "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-project",                                                  "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-project",                                                  "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-powerpoint",                                               "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint",                                               "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint",                                               "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint",                                               "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.visio",                                                       "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.visio",                                                       "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.visio",                                                       "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.visio",                                                       "targetMediaType": "text/xml"}
+      ],
+      "transformOptions": [
+        "tikaOptions"
+      ]
+    },
+    {
+      "transformerName": "poi",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/vnd.ms-excel",                                                    "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.ms-excel",                                                    "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-excel",                                                    "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-excel",                                                    "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-excel",                                                    "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "text/xml"}
+      ],
+      "transformOptions": [
+        "tikaOptions"
+      ]
+    },
+    {
+      "transformerName": "ooxml",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/vnd.ms-word.document.macroenabled.12",                            "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-word.document.macroenabled.12",                            "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-word.document.macroenabled.12",                            "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-word.document.macroenabled.12",                            "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",     "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",     "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",     "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",     "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-word.template.macroenabled.12",                            "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-word.template.macroenabled.12",                            "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-word.template.macroenabled.12",                            "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-word.template.macroenabled.12",                            "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",     "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",     "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",     "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",     "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-powerpoint.template.macroenabled.12",                      "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.template.macroenabled.12",                      "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.template.macroenabled.12",                      "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.template.macroenabled.12",                      "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.template",       "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.template",       "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.template",       "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.template",       "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-powerpoint.addin.macroenabled.12",                         "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.addin.macroenabled.12",                         "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.addin.macroenabled.12",                         "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.addin.macroenabled.12",                         "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-powerpoint.slideshow.macroenabled.12",                     "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.slideshow.macroenabled.12",                     "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.slideshow.macroenabled.12",                     "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.slideshow.macroenabled.12",                     "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",      "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",      "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",      "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",      "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-powerpoint.presentation.macroenabled.12",                  "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.presentation.macroenabled.12",                  "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.presentation.macroenabled.12",                  "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.presentation.macroenabled.12",                  "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",   "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",   "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",   "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",   "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-powerpoint.slide.macroenabled.12",                         "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.slide.macroenabled.12",                         "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.slide.macroenabled.12",                         "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-powerpoint.slide.macroenabled.12",                         "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slide",          "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slide",          "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slide",          "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slide",          "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-excel.addin.macroenabled.12",                              "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-excel.addin.macroenabled.12",                              "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-excel.addin.macroenabled.12",                              "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-excel.addin.macroenabled.12",                              "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-excel.sheet.binary.macroenabled.12",                       "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-excel.sheet.binary.macroenabled.12",                       "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-excel.sheet.binary.macroenabled.12",                       "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-excel.sheet.binary.macroenabled.12",                       "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-excel.sheet.macroenabled.12",                              "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-excel.sheet.macroenabled.12",                              "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-excel.sheet.macroenabled.12",                              "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-excel.sheet.macroenabled.12",                              "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",           "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.ms-excel.template.macroenabled.12",                           "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.ms-excel.template.macroenabled.12",                           "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.ms-excel.template.macroenabled.12",                           "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.ms-excel.template.macroenabled.12",                           "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",        "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",        "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",        "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",        "targetMediaType": "text/xml"}
+      ],
+      "transformOptions": [
+        "tikaOptions"
+      ]
+    },
+    {
+      "transformerName": "tikaAuto",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/java-archive",                                                    "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/java-archive",                                                    "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/java-archive",                                                    "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/java-archive",                                                    "targetMediaType": "text/xml"},
 
         {"sourceMediaType": "application/x-netcdf",                                                        "targetMediaType": "text/html"},
         {"sourceMediaType": "application/x-netcdf",                                                        "targetMediaType": "text/plain"},
@@ -282,12 +476,19 @@
         {"sourceMediaType": "application/x-compress",                                                      "targetMediaType": "text/html"},
         {"sourceMediaType": "application/x-compress",                                                      "targetMediaType": "text/plain"},
         {"sourceMediaType": "application/x-compress",                                                      "targetMediaType": "application/xhtml+xml"},
-        {"sourceMediaType": "application/x-compress",                                                      "targetMediaType": "text/xml"},
-
-        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/html"},
-        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/plain"},
-        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "application/xhtml+xml"},
-        {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/xml"}
+        {"sourceMediaType": "application/x-compress",                                                      "targetMediaType": "text/xml"}
+      ],
+      "transformOptions": [
+        "tikaOptions"
+      ]
+    },
+    {
+      "transformerName": "textMining",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/msword",                                                          "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/xml"}
       ],
       "transformOptions": [
         "tikaOptions"

--- a/alfresco-docker-tika/src/main/resources/engine_config.json
+++ b/alfresco-docker-tika/src/main/resources/engine_config.json
@@ -1,16 +1,20 @@
 {
   "transformOptions": {
     "tikaOptions": [
-      {"value": {"required":true, "name": "transform" }},
+      {"value": {"name": "targetEncoding"}}
+    ],
+    "archiveOptions": [
       {"value": {"name": "includeContents"}},
+      {"value": {"name": "targetEncoding"}}
+    ],
+    "pdfboxOptions": [
       {"value": {"name": "notExtractBookmarksText"}},
-      {"value": {"required":true, "name": "targetMimetype"}},
-      {"value": {"required":true, "name": "targetEncoding"}}
+      {"value": {"name": "targetEncoding"}}
     ]
   },
   "transformers": [
     {
-      "transformerName": "archive",
+      "transformerName": "Archive",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/html"},
         {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/plain"},
@@ -33,11 +37,11 @@
         {"sourceMediaType": "application/zip",                                                             "targetMediaType": "text/xml"}
       ],
       "transformOptions": [
-        "tikaOptions"
+        "archiveOptions"
       ]
     },
     {
-      "transformerName": "outlookMsg",
+      "transformerName": "OutlookMsg",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/html"},
         {"sourceMediaType": "application/vnd.ms-outlook",                                                  "targetMediaType": "text/plain"},
@@ -49,7 +53,7 @@
       ]
     },
     {
-      "transformerName": "pdfbox",
+      "transformerName": "PdfBox",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/pdf",                                                             "targetMediaType": "text/html"},
         {"sourceMediaType": "application/pdf",                             "maxSourceSizeBytes": 26214400, "targetMediaType": "text/plain"},
@@ -57,11 +61,11 @@
         {"sourceMediaType": "application/pdf",                                                             "targetMediaType": "text/xml"}
       ],
       "transformOptions": [
-        "tikaOptions"
+        "pdfboxOptions"
       ]
     },
     {
-      "transformerName": "office",
+      "transformerName": "Office",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/html"},
         {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/plain"},
@@ -93,7 +97,7 @@
       ]
     },
     {
-      "transformerName": "poi",
+      "transformerName": "Poi",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/vnd.ms-excel",                                                    "targetMediaType": "text/csv"},
         {"sourceMediaType": "application/vnd.ms-excel",                                                    "targetMediaType": "text/html"},
@@ -112,7 +116,7 @@
       ]
     },
     {
-      "transformerName": "ooxml",
+      "transformerName": "OOXML",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/vnd.ms-word.document.macroenabled.12",                            "targetMediaType": "text/html"},
         {"sourceMediaType": "application/vnd.ms-word.document.macroenabled.12",                            "targetMediaType": "text/plain"},
@@ -214,7 +218,7 @@
       ]
     },
     {
-      "transformerName": "tikaAuto",
+      "transformerName": "TikaAuto",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/html"},
         {"sourceMediaType": "application/x-cpio",                                                          "targetMediaType": "text/plain"},
@@ -483,7 +487,7 @@
       ]
     },
     {
-      "transformerName": "textMining",
+      "transformerName": "TextMining",
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/html"},
         {"sourceMediaType": "application/msword",                                                          "targetMediaType": "text/plain"},

--- a/alfresco-docker-tika/src/main/resources/templates/transformForm.html
+++ b/alfresco-docker-tika/src/main/resources/templates/transformForm.html
@@ -5,20 +5,8 @@
 		<h2>Tika Test Transformations</h2>
         <form method="POST" enctype="multipart/form-data" action="/transform">
             <table>
-                <tr><td><div style="text-align:right">transform *</div></td><td><select name="transform">
-                    <option value="Archive">Archive</option>
-                    <option value="OutlookMsg">OutlookMsg</option>
-                    <option selected="selected" value="PdfBox">PdfBox</option>
-                    <option value="Office">Office</option>
-                    <option value="Poi">Poi</option>
-                    <option value="OOXML">OOXML</option>
-                    <option value="TikaAuto">TikaAuto</option>
-                    <option value="TextMining">TextMining</option>
-                    <option value="UNSET"></option>
-                    <option value="BADVALUE">BADVALUE</option>
-                    <option value="MIXED CASE TikaAuto">TikaAuto</option>
-                </select></td></tr>
                 <tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr>
+                <tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" value="text/plain" /></td></tr>
                 <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" value="txt" /></td></tr>
                 <tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" value="text/plain" /></td></tr>
                 <tr><td><div style="text-align:right">targetEncoding *</div></td><td><input type="text" name="targetEncoding" value="UTF-8" /></td></tr>

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transform/client/model/config/CombinedConfig.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transform/client/model/config/CombinedConfig.java
@@ -1,0 +1,306 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2019 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.transform.client.model.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class recreates the json format used in ACS 6.1 where we just had an array of transformers and each
+ * transformer has a list of node options. The idea of this code is that it replaces the references with the
+ * actual node options that have been separated out into their own section.<p>
+ *
+ * The T-Router and T-Engines return the format with the node option separated into their own section. Pipeline
+ * definitions used by the LocalTransformServiceRegistry may use node reference options defined in the json
+ * returned by T-Engines.  with the actual definitions from the node options
+ * reference section. It also combines multiple json sources into a single jsonNode structure that can be parsed as
+ * before.
+ */
+public class CombinedConfig
+{
+    private static final String TRANSFORMER_NAME = "transformerName";
+    private static final String TRANSFORM_CONFIG = "/transform/config";
+    private static final String TRANSFORM_OPTIONS = "transformOptions";
+    private static final String GROUP = "group";
+    private static final String TRANSFORMERS = "transformers";
+
+    private final Logger log;
+    private Map<String, ArrayNode> allTransformOptions = new HashMap<>();
+    private List<TransformNodeAndItsOrigin> allTransforms = new ArrayList<>();
+    private ObjectMapper jsonObjectMapper = new ObjectMapper();
+    private ConfigFileFinder configFileFinder;
+    private int tEngineCount;
+
+    static class TransformNodeAndItsOrigin
+    {
+        final ObjectNode node;
+        final String baseUrl;
+        final String readFrom;
+
+        TransformNodeAndItsOrigin(ObjectNode node, String baseUrl, String readFrom)
+        {
+            this.node = node;
+            this.baseUrl = baseUrl;
+            this.readFrom = readFrom;
+        }
+    }
+
+    static class TransformAndItsOrigin
+    {
+        final InlineTransformer transform;
+        final String baseUrl;
+        final String readFrom;
+
+        TransformAndItsOrigin(InlineTransformer transform, String baseUrl, String readFrom)
+        {
+            this.transform = transform;
+            this.baseUrl = baseUrl;
+            this.readFrom = readFrom;
+        }
+    }
+
+    public CombinedConfig(Logger log)
+    {
+        this.log = log;
+
+        configFileFinder = new ConfigFileFinder(jsonObjectMapper)
+        {
+            @Override
+            protected void readJson(JsonNode jsonNode, String readFromMessage, String baseUrl) throws IOException
+            {
+                JsonNode transformOptions = jsonNode.get(TRANSFORM_OPTIONS);
+                if (transformOptions != null && transformOptions.isObject())
+                {
+                    Iterator<Map.Entry<String, JsonNode>> iterator = transformOptions.fields();
+                    while (iterator.hasNext())
+                    {
+                        Map.Entry<String, JsonNode> entry = iterator.next();
+
+                        JsonNode options = entry.getValue();
+                        if (options.isArray())
+                        {
+                            String optionsName = entry.getKey();
+                            allTransformOptions.put(optionsName, (ArrayNode)options);
+                        }
+                    }
+                }
+
+                JsonNode transformers = jsonNode.get(TRANSFORMERS);
+                if (transformers != null && transformers.isArray())
+                {
+                    for (JsonNode transformer : transformers)
+                    {
+                        if (transformer.isObject())
+                        {
+                            allTransforms.add(new TransformNodeAndItsOrigin((ObjectNode)transformer, baseUrl, readFromMessage));
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    public boolean addLocalConfig(String path) throws IOException
+    {
+        return configFileFinder.readFiles(path, log);
+    }
+
+    public void register(TransformRegistry registry) throws IOException
+    {
+        List<TransformAndItsOrigin> transformers = getTransforms();
+        transformers.forEach(t->registry.register(t.transform));
+    }
+
+    public List<TransformAndItsOrigin> getTransforms() throws IOException
+    {
+        List<TransformAndItsOrigin> transforms = new ArrayList<>();
+
+        // After all json input has been loaded build the output with the options in place.
+        ArrayNode transformersNode = jsonObjectMapper.createArrayNode();
+        for (TransformNodeAndItsOrigin entity : allTransforms)
+        {
+            transformersNode.add(entity.node);
+
+            try
+            {
+                ArrayNode transformOptions = (ArrayNode) entity.node.get(TRANSFORM_OPTIONS);
+                if (transformOptions != null)
+                {
+
+                    ArrayNode options;
+                    int size = transformOptions.size();
+                    if (size == 1)
+                    {
+                        // If there is a single node option reference, we can just use it.
+                        int i = 0;
+                        options = getTransformOptions(transformOptions, i, entity.node);
+                    }
+                    else
+                    {
+                        // If there are many node option references (typically in a pipeline), then each element
+                        // has a group for each set of node options.
+                        options = jsonObjectMapper.createArrayNode();
+                        for (int i = size - 1; i >= 0; i--)
+                        {
+                            JsonNode referencedTransformOptions = getTransformOptions(transformOptions, i, entity.node);
+                            if (referencedTransformOptions != null)
+                            {
+                                ObjectNode element = jsonObjectMapper.createObjectNode();
+                                options.add(element);
+
+                                ObjectNode group = jsonObjectMapper.createObjectNode();
+                                group.set(TRANSFORM_OPTIONS, referencedTransformOptions);
+                                element.set(GROUP, group);
+                            }
+                        }
+                    }
+                    if (options == null || options.size() == 0)
+                    {
+                        entity.node.remove(TRANSFORM_OPTIONS);
+                    }
+                    else
+                    {
+                        entity.node.set(TRANSFORM_OPTIONS, options);
+                    }
+                }
+
+                try
+                {
+                    InlineTransformer transform = jsonObjectMapper.convertValue(entity.node, InlineTransformer.class);
+                    transforms.add(new TransformAndItsOrigin(transform, entity.baseUrl, entity.readFrom));
+                }
+                catch (IllegalArgumentException e)
+                {
+                    log.error("Invalid transformer "+getTransformName(entity.node)+" "+e.getMessage()+" baseUrl="+entity.baseUrl);
+                }
+            }
+            catch (IllegalArgumentException e)
+            {
+                String transformString = jsonObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(entity.node);
+                log.error(e.getMessage());
+                log.debug(transformString);
+            }
+        }
+        if (log.isTraceEnabled())
+        {
+            log.trace("Combined config:\n"+jsonObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(transformersNode));
+        }
+
+        transforms = sortTransformers(transforms);
+        return transforms;
+    }
+
+    // Sort transformers so there are no forward references, if that is possible.
+    private List<TransformAndItsOrigin> sortTransformers(List<TransformAndItsOrigin> original)
+    {
+        List<TransformAndItsOrigin> transformers = new ArrayList<>(original.size());
+        List<TransformAndItsOrigin> todo = new ArrayList<>(original.size());
+        Set<String> transformerNames = new HashSet<>();
+        boolean added;
+        do
+        {
+            added = false;
+            for (TransformAndItsOrigin entry : original)
+            {
+                String name = entry.transform.getTransformerName();
+                List<TransformStep> pipeline = entry.transform.getTransformerPipeline();
+                boolean addEntry = true;
+                if (pipeline != null && !pipeline.isEmpty())
+                {
+                    for (TransformStep step : pipeline)
+                    {
+                        String stepName = step.getTransformerName();
+                        if (!transformerNames.contains(stepName))
+                        {
+                            todo.add(entry);
+                            addEntry = false;
+                            break;
+                        }
+                    }
+                }
+                if (addEntry)
+                {
+                    transformers.add(entry);
+                    added = true;
+                    if (name != null)
+                    {
+                        transformerNames.add(name);
+                    }
+                }
+            }
+
+            original.clear();
+            original.addAll(todo);
+            todo.clear();
+        }
+        while (added && !original.isEmpty());
+
+        transformers.addAll(todo);
+
+        return transformers;
+    }
+
+    private ArrayNode getTransformOptions(ArrayNode transformOptions, int i, ObjectNode transform)
+    {
+        ArrayNode options = null;
+        JsonNode optionName = transformOptions.get(i);
+        if (optionName.isTextual())
+        {
+            String name = optionName.asText();
+            options = allTransformOptions.get(name);
+            if (options == null)
+            {
+                String message = "Reference to \"transformOptions\": \"" + name + "\" not found. Transformer " +
+                        getTransformName(transform) + " ignored.";
+                throw new IllegalArgumentException(message);
+            }
+        }
+        return options;
+    }
+
+    private String getTransformName(ObjectNode transform)
+    {
+        String name = "Unknown";
+        JsonNode nameNode = transform.get(TRANSFORMER_NAME);
+        if (nameNode != null && nameNode.isTextual())
+        {
+            name = '"'+nameNode.asText()+'"';
+        }
+        return name;
+    }
+}

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transform/client/model/config/ConfigFileFinder.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transform/client/model/config/ConfigFileFinder.java
@@ -1,0 +1,209 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.transform.client.model.config;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Used to find configuration files as resources from the jar file or from some external location. The path supplied
+ * to {@link #readFiles(String, Logger)} may be a directory name. Normally used by ConfigScheduler.
+ *
+ * @author adavis
+ */
+public abstract class ConfigFileFinder
+{
+    private final ObjectMapper jsonObjectMapper;
+    private int fileCount;
+
+    public ConfigFileFinder(ObjectMapper jsonObjectMapper)
+    {
+        this.jsonObjectMapper = jsonObjectMapper;
+    }
+
+    public boolean readFiles(String path, Logger log)
+    {
+        AtomicBoolean successReadingConfig = new AtomicBoolean(true);
+        try
+        {
+            AtomicBoolean somethingRead = new AtomicBoolean(false);
+
+            // Try reading resources in a jar
+            final File jarFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().getPath());
+            if (jarFile.isFile())
+            {
+                readFromJar(jarFile, path, log, successReadingConfig, somethingRead);
+            }
+            else
+            {
+                // Try reading resources from disk
+                URL url = getClass().getClassLoader().getResource(path);
+                if (url != null)
+                {
+                    String urlPath = url.getPath();
+                    readFromDisk(urlPath, log, successReadingConfig, somethingRead);
+                }
+            }
+
+            if (!somethingRead.get() && new File(path).exists())
+            {
+                // Try reading files from disk
+                readFromDisk(path, log, successReadingConfig, somethingRead);
+            }
+
+            if (!somethingRead.get())
+            {
+                log.warn("No config read from "+path);
+            }
+        }
+        catch (IOException e)
+        {
+            log.error("Error reading from "+path);
+            successReadingConfig.set(false);
+        }
+        return successReadingConfig.get();
+    }
+
+    private void readFromJar(File jarFile, String path, Logger log, AtomicBoolean successReadingConfig, AtomicBoolean somethingRead) throws IOException
+    {
+        JarFile jar = new JarFile(jarFile);
+        try
+        {
+            Enumeration<JarEntry> entries = jar.entries(); // gives ALL entries in jar
+            String prefix = path + "/";
+            List<String> names = new ArrayList<>();
+            while (entries.hasMoreElements())
+            {
+                final String name = entries.nextElement().getName();
+                if ((name.startsWith(prefix) && name.length() > prefix.length()) ||
+                        (name.equals(path)))
+                {
+                    names.add(name);
+                }
+            }
+            Collections.sort(names);
+            for (String name : names)
+            {
+                InputStreamReader reader = new InputStreamReader(getResourceAsStream(name));
+                readFromReader(successReadingConfig, somethingRead, reader, "resource", name, null, log);
+            }
+        }
+        finally
+        {
+            jar.close();
+        }
+    }
+
+    private void readFromDisk(String path, Logger log, AtomicBoolean successReadingConfig, AtomicBoolean somethingRead) throws FileNotFoundException
+    {
+        File root = new File(path);
+        if (root.isDirectory())
+        {
+            File[] files = root.listFiles();
+            Arrays.sort(files, (file1, file2) -> file1.getName().compareTo(file2.getName()));
+            for (File file : files)
+            {
+                FileReader reader = new FileReader(file);
+                String filePath = file.getPath();
+                readFromReader(successReadingConfig, somethingRead, reader, "file", filePath, null, log);
+            }
+        }
+        else
+        {
+            FileReader reader = new FileReader(root);
+            String filePath = root.getPath();
+            readFromReader(successReadingConfig, somethingRead, reader, "file", filePath, null, log);
+        }
+    }
+
+    private InputStream getResourceAsStream(String resource)
+    {
+        final InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        return in == null ? getClass().getResourceAsStream(resource) : in;
+    }
+
+    private void readFromReader(AtomicBoolean successReadingConfig, AtomicBoolean somethingRead,
+                                Reader reader, String readFrom, String path, String baseUrl, Logger log)
+    {
+        somethingRead.set(true);
+        boolean success = readFile(reader, readFrom, path, null, log);
+        if (success)
+        {
+            fileCount++;
+        }
+        boolean newSuccessReadingConfig = successReadingConfig.get();
+        newSuccessReadingConfig &= success;
+        successReadingConfig.set(newSuccessReadingConfig);
+    }
+
+    public boolean readFile(Reader reader, String readFrom, String path, String baseUrl, Logger log)
+    {
+        // At the moment it is assumed the file is Json, but that does not need to be the case.
+        // We have the path including extension.
+        boolean successReadingConfig = true;
+        try
+        {
+            JsonNode jsonNode = jsonObjectMapper.readValue(reader, new TypeReference<JsonNode>() {});
+            String readFromMessage = readFrom + ' ' + path;
+            if (log.isTraceEnabled())
+            {
+                log.trace(readFromMessage + " config is: " + jsonNode);
+            }
+            else
+            {
+                log.debug(readFromMessage + " config read");
+            }
+            readJson(jsonNode, readFromMessage, baseUrl);
+        }
+        catch (Exception e)
+        {
+            log.error("Error reading "+path);
+            successReadingConfig = false;
+        }
+        return successReadingConfig;
+    }
+
+    protected abstract void readJson(JsonNode jsonNode, String readFromMessage, String baseUrl) throws IOException;
+}

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transform/client/model/config/TransformRegistry.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transform/client/model/config/TransformRegistry.java
@@ -1,0 +1,336 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2018 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.transform.client.model.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Used by clients to work out if a transformation is supported based on the engine_config.json.
+ */
+public class TransformRegistry
+{
+    private static final Logger logger = LoggerFactory.getLogger(TransformRegistry.class);
+    private static final String TIMEOUT = "timeout";
+
+    private static class SupportedTransform
+    {
+        TransformOptionGroup transformOptions;
+        long maxSourceSizeBytes;
+        private String name;
+        private int priority;
+
+        public SupportedTransform(String name, Set<TransformOption> transformOptions, long maxSourceSizeBytes, int priority)
+        {
+            // Logically the top level TransformOptionGroup is required, so that child options are optional or required
+            // based on their own setting.
+            this.transformOptions = new TransformOptionGroup(true, transformOptions);
+            this.maxSourceSizeBytes = maxSourceSizeBytes;
+            this.name = name;
+            this.priority = priority;
+        }
+    }
+
+    ConcurrentMap<String, ConcurrentMap<String, List<SupportedTransform>>> transformers = new ConcurrentHashMap<>();
+    ConcurrentMap<String, ConcurrentMap<String, List<SupportedTransform>>> cachedSupportedTransformList = new ConcurrentHashMap<>();
+
+    public TransformRegistry()
+    {
+        try
+        {
+            CombinedConfig combinedConfig = new CombinedConfig(logger);
+            combinedConfig.addLocalConfig("engine_config.json");
+            combinedConfig.register(this);
+        }
+        catch (IOException e)
+        {
+            logger.error("Failed to read engine_config.json.", e);
+        }
+    }
+
+    public void register(InlineTransformer transformer)
+    {
+        transformer.getSupportedSourceAndTargetList().forEach(
+                e -> transformers.computeIfAbsent(e.getSourceMediaType(),
+                        k -> new ConcurrentHashMap<>()).computeIfAbsent(e.getTargetMediaType(),
+                        k -> new ArrayList<>()).add(
+                        new SupportedTransform(transformer.getTransformerName(),
+                                transformer.getTransformOptions(), e.getMaxSourceSizeBytes(), e.getPriority())));
+    }
+
+    public boolean isSupported(String sourceMimetype, long sourceSizeInBytes, String targetMimetype,
+                               Map<String, String> actualOptions, String renditionName)
+    {
+        long maxSize = getMaxSize(sourceMimetype, targetMimetype, actualOptions, renditionName);
+        return maxSize != 0 && (maxSize == -1L || maxSize >= sourceSizeInBytes);
+    }
+
+    /**
+     * Works out the name of the transformer (might not map to an actual transformer) that will be used to transform
+     * content of a given source mimetype and size into a target mimetype given a list of actual transform option names
+     * and values (Strings) plus the data contained in the {@Transform} objects registered with this class.
+     * @param sourceMimetype the mimetype of the source content
+     * @param sourceSizeInBytes the size in bytes of the source content. Ignored if negative.
+     * @param targetMimetype the mimetype of the target
+     * @param actualOptions the actual name value pairs available that could be passed to the Transform Service.
+     * @param renditionName (optional) name for the set of options and target mimetype. If supplied is used to cache
+     *                      results to avoid having to work out if a given transformation is supported a second time.
+     *                      The sourceMimetype and sourceSizeInBytes may still change. In the case of ACS this is the
+     *                      rendition name.
+     */
+    public String getTransformerName(String sourceMimetype, long sourceSizeInBytes, String targetMimetype, Map<String, String> actualOptions, String renditionName)
+    {
+        List<SupportedTransform> supportedTransforms = getTransformListBySize(sourceMimetype, targetMimetype, actualOptions, renditionName);
+        for (SupportedTransform supportedTransform : supportedTransforms)
+        {
+            if (supportedTransform.maxSourceSizeBytes == -1 || supportedTransform.maxSourceSizeBytes >= sourceSizeInBytes)
+            {
+                return supportedTransform.name;
+            }
+        }
+
+        return null;
+    }
+
+    public long getMaxSize(String sourceMimetype, String targetMimetype,
+                           Map<String, String> actualOptions, String renditionName)
+    {
+        List<SupportedTransform> supportedTransforms = getTransformListBySize(sourceMimetype, targetMimetype, actualOptions, renditionName);
+        return supportedTransforms.isEmpty() ? 0 : supportedTransforms.get(supportedTransforms.size()-1).maxSourceSizeBytes;
+    }
+
+    // Returns transformers in increasing supported size order, where lower priority transformers for the same size have
+    // been discarded.
+    private List<SupportedTransform> getTransformListBySize(String sourceMimetype, String targetMimetype,
+                                                            Map<String, String> actualOptions, String renditionName)
+    {
+        if (actualOptions == null)
+        {
+            actualOptions = Collections.EMPTY_MAP;
+        }
+        if (renditionName != null && renditionName.trim().isEmpty())
+        {
+            renditionName = null;
+        }
+
+        List<SupportedTransform> transformListBySize = renditionName == null ? null
+                : cachedSupportedTransformList.computeIfAbsent(renditionName, k -> new ConcurrentHashMap<>()).get(sourceMimetype);
+        if (transformListBySize != null)
+        {
+            return transformListBySize;
+        }
+
+        // Remove the "timeout" property from the actualOptions as it is not used to select a transformer.
+        if (actualOptions.containsKey(TIMEOUT))
+        {
+            actualOptions = new HashMap(actualOptions);
+            actualOptions.remove(TIMEOUT);
+        }
+
+        transformListBySize = new ArrayList<>();
+        ConcurrentMap<String, List<SupportedTransform>> targetMap = transformers.get(sourceMimetype);
+        if (targetMap !=  null)
+        {
+            List<SupportedTransform> supportedTransformList = targetMap.get(targetMimetype);
+            if (supportedTransformList != null)
+            {
+                for (SupportedTransform supportedTransform : supportedTransformList)
+                {
+                    TransformOptionGroup transformOptions = supportedTransform.transformOptions;
+                    Map<String, Boolean> possibleTransformOptions = new HashMap<>();
+                    addToPossibleTransformOptions(possibleTransformOptions, transformOptions, true, actualOptions);
+                    if (isSupported(possibleTransformOptions, actualOptions))
+                    {
+                        addToSupportedTransformList(transformListBySize, supportedTransform);
+                    }
+                }
+            }
+        }
+
+        if (renditionName != null)
+        {
+            cachedSupportedTransformList.get(renditionName).put(sourceMimetype, transformListBySize);
+        }
+
+        return transformListBySize;
+    }
+
+    // Add newTransform to the transformListBySize in increasing size order and discards lower priority (numerically
+    // higher) transforms with a smaller or equal size.
+    private void addToSupportedTransformList(List<SupportedTransform> transformListBySize, SupportedTransform newTransform)
+    {
+        for (int i=0; i < transformListBySize.size(); i++)
+        {
+            SupportedTransform existingTransform = transformListBySize.get(i);
+            int added = -1;
+            int compare = compare(newTransform.maxSourceSizeBytes, existingTransform.maxSourceSizeBytes);
+            if (compare < 0)
+            {
+                transformListBySize.add(i, newTransform);
+                added = i;
+            }
+            else if (compare == 0)
+            {
+                if (newTransform.priority < existingTransform.priority)
+                {
+                    transformListBySize.set(i, newTransform);
+                    added = i;
+                }
+            }
+            if (added == i)
+            {
+                for (i--; i >= 0; i--)
+                {
+                    existingTransform = transformListBySize.get(i);
+                    if (newTransform.priority <= existingTransform.priority)
+                    {
+                        transformListBySize.remove(i);
+                    }
+                }
+                return;
+            }
+        }
+        transformListBySize.add(newTransform);
+    }
+
+    // compare where -1 is unlimited.
+    private int compare(long a, long b)
+    {
+        return a == -1
+                ? b == -1 ? 0 : 1
+                : b == -1 ? -1
+                : a == b ? 0
+                : a > b ? 1 : -1;
+    }
+
+    /**
+     * Flatten out the transform options by adding them to the supplied possibleTransformOptions.</p>
+     *
+     * If possible discards options in the supplied transformOptionGroup if the group is optional and the actualOptions
+     * don't provide any of the options in the group. Or to put it another way:<p/>
+     *
+     * It adds individual transform options from the transformOptionGroup to possibleTransformOptions if the group is
+     * required or if the actualOptions include individual options from the group. As a result it is possible that none
+     * of the group are added if it is optional. It is also possible to add individual transform options that are
+     * themselves required but not in the actualOptions. In this the isSupported method will return false.
+     * @return true if any options were added. Used by nested call parents to determine if an option was added from a
+     * nested sub group.
+     */
+    boolean addToPossibleTransformOptions(Map<String, Boolean> possibleTransformOptions,
+                                          TransformOptionGroup transformOptionGroup,
+                                          Boolean parentGroupRequired, Map<String, String> actualOptions)
+    {
+        boolean added = false;
+        boolean required = false;
+
+        Set<TransformOption> optionList = transformOptionGroup.getTransformOptions();
+        if (optionList != null && !optionList.isEmpty())
+        {
+            // We need to avoid adding options from a group that is required but its parents are not.
+            boolean transformOptionGroupRequired = transformOptionGroup.isRequired() && parentGroupRequired;
+
+            // Check if the group contains options in actualOptions. This will add any options from sub groups.
+            for (TransformOption transformOption : optionList)
+            {
+                if (transformOption instanceof TransformOptionGroup)
+                {
+                    added = addToPossibleTransformOptions(possibleTransformOptions, (TransformOptionGroup) transformOption,
+                            transformOptionGroupRequired, actualOptions);
+                    required |= added;
+                }
+                else
+                {
+                    String name = ((TransformOptionValue) transformOption).getName();
+                    if (actualOptions.containsKey(name))
+                    {
+                        required = true;
+                    }
+                }
+            }
+
+            if (required || transformOptionGroupRequired)
+            {
+                for (TransformOption transformOption : optionList)
+                {
+                    if (transformOption instanceof TransformOptionValue)
+                    {
+                        added = true;
+                        TransformOptionValue transformOptionValue = (TransformOptionValue) transformOption;
+                        String name = transformOptionValue.getName();
+                        boolean optionValueRequired = transformOptionValue.isRequired();
+                        possibleTransformOptions.put(name, optionValueRequired);
+                    }
+                }
+            }
+        }
+
+        return added;
+    }
+
+    boolean isSupported(Map<String, Boolean> transformOptions, Map<String, String> actualOptions)
+    {
+        boolean supported = true;
+
+        // Check all required transformOptions are supplied
+        for (Map.Entry<String, Boolean> transformOption : transformOptions.entrySet())
+        {
+            Boolean required = transformOption.getValue();
+            if (required)
+            {
+                String name = transformOption.getKey();
+                if (!actualOptions.containsKey(name))
+                {
+                    supported = false;
+                    break;
+                }
+            }
+        }
+
+        if (supported)
+        {
+            // Check there are no extra unused actualOptions
+            for (String actualOption : actualOptions.keySet())
+            {
+                if (!transformOptions.containsKey(actualOption))
+                {
+                    supported = false;
+                    break;
+                }
+            }
+        }
+        return supported;
+    }
+}

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/config/WebApplicationConfig.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/config/WebApplicationConfig.java
@@ -27,6 +27,7 @@
 package org.alfresco.transformer.config;
 
 import org.alfresco.transform.client.model.TransformRequestValidator;
+import org.alfresco.transform.client.model.config.TransformRegistry;
 import org.alfresco.transformer.TransformInterceptor;
 import org.alfresco.transformer.clients.AlfrescoSharedFileStoreClient;
 import org.springframework.context.annotation.Bean;
@@ -68,5 +69,11 @@ public class WebApplicationConfig implements WebMvcConfigurer
     public TransformRequestValidator transformRequestValidator()
     {
         return new TransformRequestValidator();
+    }
+
+    @Bean
+    public TransformRegistry transformRegistry()
+    {
+        return new TransformRegistry();
     }
 }


### PR DESCRIPTION
The Tika T-Engine "transform" option does not exist when called via the Transform Service or Local transforms, which resulted in no transforms taking place. However this value is really not be needed as the T-Engine should be able to read its own engine_config.xml to work out which sub transform to use. Transforms only worked via Legacy transforms, which used a T-Engine.

This code is based on tried and tested ACS repository code. It has been further simplified.

TODO:
- replace the ConfigFileFinder class just added with something that uses Spring to read the JSON. i.e. simplify it.
- replace the CombinedConfig class just added with something that does not need the InLineTransformer. i.e. simplify it.
- create tests based on the repo tests
- remove the source and target mimetype checks in Tika as a check against engine_config.xml is cleaner.
- repeat the process for the Misc T-Engine as it has similar code checking source and target mimetypes.
- remove the transform option passed by the legacy transforms.
