### PR TITLE
REPO-4452 Local transformer pipelines - missing priorities

### DIFF
--- a/alfresco-docker-tika/src/main/resources/engine_config.json
+++ b/alfresco-docker-tika/src/main/resources/engine_config.json
@@ -319,7 +319,7 @@
         {"sourceMediaType": "application/vnd.oasis.opendocument.spreadsheet",                                              "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.spreadsheet",                                              "targetMediaType": "text/xml"},
 
-        {"sourceMediaType": "application/vnd.oasis.opendocument.text",                                                     "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.oasis.opendocument.text",                                     "priority": 55, "targetMediaType": "text/html"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.text",                                                     "targetMediaType": "text/plain"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.text",                                                     "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.text",                                                     "targetMediaType": "text/xml"},
@@ -339,12 +339,12 @@
         {"sourceMediaType": "application/vnd.oasis.opendocument.presentation-template",                                    "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.presentation-template",                                    "targetMediaType": "text/xml"},
 
-        {"sourceMediaType": "application/vnd.oasis.opendocument.spreadsheet-template",                                     "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.oasis.opendocument.spreadsheet-template",                     "priority": 55, "targetMediaType": "text/html"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.spreadsheet-template",                                     "targetMediaType": "text/plain"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.spreadsheet-template",                                     "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.spreadsheet-template",                                     "targetMediaType": "text/xml"},
 
-        {"sourceMediaType": "application/vnd.oasis.opendocument.text-template",                                            "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.oasis.opendocument.text-template",                            "priority": 55, "targetMediaType": "text/html"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.text-template",                                            "targetMediaType": "text/plain"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.text-template",                                            "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.text-template",                                            "targetMediaType": "text/xml"},
@@ -408,7 +408,7 @@
         {"sourceMediaType": "application/rss+xml",                                                                         "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/rss+xml",                                                                         "targetMediaType": "text/xml"},
 
-        {"sourceMediaType": "application/rtf",                                                                             "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/rtf",                                                             "priority": 55, "targetMediaType": "text/html"},
         {"sourceMediaType": "application/rtf",                                                                             "targetMediaType": "text/plain"},
         {"sourceMediaType": "application/rtf",                                                                             "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/rtf",                                                                             "targetMediaType": "text/xml"},
@@ -423,7 +423,7 @@
         {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slide",                          "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/vnd.openxmlformats-officedocument.presentationml.slide",                          "targetMediaType": "text/xml"},
 
-        {"sourceMediaType": "application/vnd.sun.xml.writer",                                                              "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.sun.xml.writer",                                              "priority": 55, "targetMediaType": "text/html"},
         {"sourceMediaType": "application/vnd.sun.xml.writer",                                                              "targetMediaType": "text/plain"},
         {"sourceMediaType": "application/vnd.sun.xml.writer",                                                              "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/vnd.sun.xml.writer",                                                              "targetMediaType": "text/xml"},


### PR DESCRIPTION
Sets priorities on 5 Tika transform routes so they are not used if LibreOffice is available. This currently has no impact on the Transform Service (priorities are not used for routing), but does on repository LocalTransforms as the wrong T-Engine is selected.

Fixes the routes identified as having the same priority in the last table of https://issues.alfresco.com/jira/browse/REPO-4452?focusedCommentId=636603&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-636603