### PR TITLE
ATS-648: Update ActiveMQ tests

### DIFF
--- a/alfresco-docker-alfresco-pdf-renderer/pom.xml
+++ b/alfresco-docker-alfresco-pdf-renderer/pom.xml
@@ -94,7 +94,7 @@
                             <images>
                                 <image>
                                     <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.15.6</name>
+                                    <name>alfresco/alfresco-activemq:5.15.8</name>
                                     <run>
                                         <hostname>activemq</hostname>
                                         <ports>
@@ -103,7 +103,7 @@
                                             <port>61616:61616</port>
                                         </ports>
                                         <wait>
-                                            <log>Apache ActiveMQ 5.15.6 .* started</log>
+                                            <log>Apache ActiveMQ 5.15.8 .* started</log>
                                             <time>20000</time>
                                             <kill>500</kill>
                                             <shutdown>100</shutdown>

--- a/alfresco-docker-imagemagick/pom.xml
+++ b/alfresco-docker-imagemagick/pom.xml
@@ -97,7 +97,7 @@
                             <images>
                                 <image>
                                     <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.15.6</name>
+                                    <name>alfresco/alfresco-activemq:5.15.8</name>
                                     <run>
                                         <hostname>activemq</hostname>
                                         <ports>
@@ -106,7 +106,7 @@
                                             <port>61616:61616</port>
                                         </ports>
                                         <wait>
-                                            <log>Apache ActiveMQ 5.15.6 .* started</log>
+                                            <log>Apache ActiveMQ 5.15.8 .* started</log>
                                             <time>20000</time>
                                             <kill>500</kill>
                                             <shutdown>100</shutdown>

--- a/alfresco-docker-libreoffice/pom.xml
+++ b/alfresco-docker-libreoffice/pom.xml
@@ -107,7 +107,7 @@
                             <images>
                                 <image>
                                     <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.15.6</name>
+                                    <name>alfresco/alfresco-activemq:5.15.8</name>
                                     <run>
                                         <hostname>activemq</hostname>
                                         <ports>
@@ -116,7 +116,7 @@
                                             <port>61616:61616</port>
                                         </ports>
                                         <wait>
-                                            <log>Apache ActiveMQ 5.15.6 .* started</log>
+                                            <log>Apache ActiveMQ 5.15.8 .* started</log>
                                             <time>20000</time>
                                             <kill>500</kill>
                                             <shutdown>100</shutdown>

--- a/alfresco-docker-tika/pom.xml
+++ b/alfresco-docker-tika/pom.xml
@@ -166,7 +166,7 @@
                             <images>
                                 <image>
                                     <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.15.6</name>
+                                    <name>alfresco/alfresco-activemq:5.15.8</name>
                                     <run>
                                         <hostname>activemq</hostname>
                                         <ports>
@@ -175,7 +175,7 @@
                                             <port>61616:61616</port>
                                         </ports>
                                         <wait>
-                                            <log>Apache ActiveMQ 5.15.6 .* started</log>
+                                            <log>Apache ActiveMQ 5.15.8 .* started</log>
                                             <time>20000</time>
                                             <kill>500</kill>
                                             <shutdown>100</shutdown>

--- a/alfresco-docker-transform-misc/pom.xml
+++ b/alfresco-docker-transform-misc/pom.xml
@@ -130,7 +130,7 @@
                             <images>
                                 <image>
                                     <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.15.6</name>
+                                    <name>alfresco/alfresco-activemq:5.15.8</name>
                                     <run>
                                         <hostname>activemq</hostname>
                                         <ports>
@@ -139,7 +139,7 @@
                                             <port>61616:61616</port>
                                         </ports>
                                         <wait>
-                                            <log>Apache ActiveMQ 5.15.6 .* started</log>
+                                            <log>Apache ActiveMQ 5.15.8 .* started</log>
                                             <time>20000</time>
                                             <kill>500</kill>
                                             <shutdown>100</shutdown>


### PR DESCRIPTION
- ActiveMQ 5.15.8 (from 5.15.6)