### PR TITLE
ATS-655: Update AIO java base image

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
@@ -5,7 +5,7 @@
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.1-openjdk-centos-7-6784d76a7b81
+FROM alfresco/alfresco-base-java:11.0.1-openjdk-centos-7-72b88c6f1f4c
 
 ENV APACHE_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/Apache%202.0.txt
 


### PR DESCRIPTION
- fallout from ATS-693
- update Dockerfile to use same Java Base Image as other x5 (ATS-711) 
- see also DEPLOY-924 / ATS-655