### PR TITLE
ATS-676 - test release of T-Core (T-Engines) 2.2.0-TEST1 [trigger release]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
       if: commit_message ~= /\[trigger release\]/ AND branch ~= /^(master|SP\/.+|HF\/.+)$/
       before_install: bash _ci/init.sh
       before_script: travis_wait bash _ci/cache_artifacts.sh
-      script: travis_wait 45 bash _ci/release.sh
+      script: travis_wait 55 bash _ci/release.sh
       before_deploy: source _ci/prepare_staging_deploy.sh
       deploy:
         provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
       if: commit_message ~= /\[trigger release\]/ AND branch ~= /^(master|SP\/.+|HF\/.+)$/
       before_install: bash _ci/init.sh
       before_script: travis_wait bash _ci/cache_artifacts.sh
-      script: travis_wait 30 bash _ci/release.sh
+      script: travis_wait 45 bash _ci/release.sh
       before_deploy: source _ci/prepare_staging_deploy.sh
       deploy:
         provider: s3

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-misc/alfresco-transform-misc/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-tika/alfresco-transform-tika/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transformer-base/pom.xml
+++ b/alfresco-transformer-base/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.2.0-A2-SNAPSHOT</version>
+        <version>2.2.0-TEST1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alfresco-transformer-base</artifactId>
-    <version>2.2.0-A2-SNAPSHOT</version>
+    <version>2.2.0-TEST1-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-transform-core</artifactId>
-    <version>2.2.0-A2-SNAPSHOT</version>
+    <version>2.2.0-TEST1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
- bump pom.xml to 2.2.0-TEST1-SNAPSHOT
- update time_wait from 30 to 45 mins (since 2.2.0-A1 may have timed-out)