### PR TITLE
ATS-718: Tweak Veracode SAST to only upload & scan delivered artefacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,9 @@ jobs:
 
     - name: "Static Analysis (SAST)"
       stage: build
-      if: branch NOT IN (company_release) AND type != pull_request
+## TODO ATS-721: comment out until it is possible to run concurrent SAST scans
+#      if: branch NOT IN (company_release) AND type != pull_request
+      if: NOT IN (company_release) AND branch = master
       before_install:
       - bash _ci/static_analysis_init.sh
       - bash _ci/init.sh

--- a/_ci/static_analysis.sh
+++ b/_ci/static_analysis.sh
@@ -12,18 +12,11 @@ java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_AP
      -vkey $VERACODE_API_KEY -action uploadandscan -appname "Transform Service" \
      ${RUN_IN_SANDBOX} -createprofile false \
      -filepath \
-     alfresco-transformer-base/target/alfresco-transformer-base-*.jar \
-     alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer/target/alfresco-transform-pdf-renderer-*.jar \
      alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/target/alfresco-transform-pdf-renderer-*.jar \
-     alfresco-transform-imagemagick/alfresco-transform-imagemagick/target/alfresco-transform-imagemagick-*.jar \
      alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/target/alfresco-transform-imagemagick-boot-*.jar \
-     alfresco-transform-libreoffice/alfresco-transform-libreoffice/target/alfresco-transform-libreoffice-*.jar \
      alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/target/alfresco-transform-libreoffice-boot-*.jar \
-     alfresco-transform-tika/alfresco-transform-tika/target/alfresco-transform-tika-*.jar \
      alfresco-transform-tika/alfresco-transform-tika-boot/target/alfresco-transform-tika-boot-*.jar \
-     alfresco-transform-misc/alfresco-transform-misc/target/alfresco-transform-misc-*.jar \
      alfresco-transform-misc/alfresco-transform-misc-boot/target/alfresco-transform-misc-boot*.jar \
-     alfresco-transform-core-aio/alfresco-transform-core-aio/target/alfresco-transform-core-aio-*.jar \
      alfresco-transform-core-aio/alfresco-transform-core-aio-boot/target/alfresco-transform-core-aio-boot*.jar \
      -version "$TRAVIS_JOB_ID - $TRAVIS_JOB_NUMBER" -scantimeout 3600
 


### PR DESCRIPTION
- ie. only upload runnable jars (Spring Boot apps) x6 (= x1 AIO core T-Engine  + x5 individual core T-Engines)
- see also ATS-711 / ATS-696 / ATS-468