### PR TITLE
ATS-714: Fix libreoffice NPE when debug enabled

### DIFF
--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice/src/main/java/org/alfresco/transformer/executors/JodConverterSharedInstance.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice/src/main/java/org/alfresco/transformer/executors/JodConverterSharedInstance.java
@@ -438,9 +438,19 @@ public class JodConverterSharedInstance implements JodConverter
         }
 
         File[] matchingFiles = searchRoot.listFiles((dir, name) -> name.startsWith("soffice"));
+        if (matchingFiles == null)
+        {
+            return results;
+        }
         results.addAll(asList(matchingFiles));
 
-        for (File dir : requireNonNull(searchRoot.listFiles(File::isDirectory)))
+        File[] matchingDirectories = searchRoot.listFiles(File::isDirectory);
+        if (matchingDirectories == null)
+        {
+            return results;
+        }
+
+        for (File dir : requireNonNull(matchingDirectories))
         {
             findSofficePrograms(dir, results, currentRecursionDepth + 1, maxRecursionDepth);
         }


### PR DESCRIPTION
Fix NPE in libreoffice when the external files are not present and debug is enabled.