### PR TITLE
ATS-725(REPO-4919) Update LibreOffice to 6.3.5 in cache_artifacts.sh

### DIFF
--- a/_ci/cache_artifacts.sh
+++ b/_ci/cache_artifacts.sh
@@ -5,7 +5,7 @@ PS4="\[\e[35m\]+ \[\e[m\]"
 set -vex
 pushd "$(dirname "${BASH_SOURCE[0]}")/../"
 
-LIBREOFFICE_VERSION=6.1.6
+LIBREOFFICE_VERSION=6.3.5
 
 # Cache the LibreOffice distribution, as it is takes a long time to download and it can cause the
 # build to fail (no output for more than 10 minutes)


### PR DESCRIPTION
Update the LibreOffice version in the cache_artifacts.sh to 6.3.5