### PR TITLE
ATS-720: Fix HTML Test Form

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/resources/templates/transformForm.html
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/resources/templates/transformForm.html
@@ -11,6 +11,12 @@
 </style>
 
 <body>
+	<div>
+		<h1>All in One Transformer Test Transformation</h1>
+	</div>
+	<div>
+		<a href="/log">Log entries</a>
+	</div>
 	<div class="transfomer">
 		<h2>Tika Test Transformations</h2>
         <form method="POST" enctype="multipart/form-data" action="/transform">
@@ -19,7 +25,7 @@
                 <tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="application/msword" /></td></tr>
 				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
 				<tr><td><div style="text-align:right">sourceExtension </div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
-				<tr><td><div style="text-align:right">targetExtension</div></td><td><input type="text" name="targetExtension" value="txt" /></td></tr>
+				<tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" required="required" value="txt" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
                 <tr><td><div style="text-align:right">targetEncoding</div></td><td><input type="text" name="targetEncoding" value="UTF-8" /></td></tr>
@@ -125,12 +131,5 @@
 			</table>
 		</form>
 	</div>
-
-	<div style="display: inline-block;">
-		<a href="/log">Log entries</a>
-	</div>
-
-    
-
 </body>
 </html>

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/resources/templates/transformForm.html
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/resources/templates/transformForm.html
@@ -4,12 +4,8 @@
 		display: inline-block;
 		padding-right: 20px;
 	}
-	a {
-		font-family:"Book Antiqua";
-		font-size:20px;
-	}
-</style>
 
+</style>
 <body>
 	<div>
 		<h1>All in One Transformer Test Transformation</h1>

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/resources/templates/transformForm.html
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/resources/templates/transformForm.html
@@ -4,66 +4,26 @@
 		display: inline-block;
 		padding-right: 20px;
 	}
+	a {
+		font-family:"Book Antiqua";
+		font-size:20px;
+	}
 </style>
-<body>
-	<div>
-		<h1>All in One Transformer Test Transformation</h1>
-		<form method="POST" enctype="multipart/form-data" action="/transform">
-            <table>
-				<tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr> <!-- Required by all transformers -->
-				<tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" value="" /></td></tr> <!-- Required by all transformers -->
-				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr> <!-- Required by all transformers -->
-				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr> <!-- Required by all transformers -->
-				<tr><td><div style="text-align:right">sourceExtension </div></td><td><input type="text" name="sourceExtension" value="" /></td></tr> <!-- Required by Misc -->				
-				<tr><td><div style="text-align:right">targetMimetype </div></td><td><input type="text" name="targetMimetype" value="" /></td></tr> <!-- Required by Tika, Misc -->
-				<tr><td><div style="text-align:right">sourceMimetype </div></td><td><input type="text" name="sourceMimetype" value="" /></td></tr> <!-- Required by Tika, Misc -->
-				<tr><td><div style="text-align:right">targetEncoding </div></td><td><input type="text" name="targetEncoding" value="" /></td></tr> <!-- Required by Tika, Misc -->
-				<tr><td><div style="text-align:right">sourceEncoding </div></td><td><input type="text" name="sourceEncoding" value="" /></td></tr> <!-- Required by Misc -->
-                <tr><td><div style="text-align:right">includeContents (archive) </div></td><td><input type="checkbox" name="includeContents" value="true" /></td></tr> <!-- Required by Tika -->
-				<tr><td><div style="text-align:right">notExtractBookmarksText</div></td><td><input type="checkbox" name="notExtractBookmarksText" value="true" /></td></tr> <!-- Required by Tika -->
-				<!-- PDF Renderer only -->
-				<tr><td><div style="text-align:right">page</div></td><td><input type="text" name="page" value="" /></td></tr>
-				<tr><td><div style="text-align:right">width</div></td><td><input type="text" name="width" value="" /></td></tr>
-				<tr><td><div style="text-align:right">height</div></td><td><input type="text" name="height" value="" /></td></tr>
-				<tr><td><div style="text-align:right">allowPdfEnlargement</div></td><td><input type="checkbox" name="allowPdfEnlargement" value="true" /></td></tr>
-				<tr><td><div style="text-align:right">maintainPdfAspectRatio</div></td><td><input type="checkbox" name="maintainPdfAspectRatio" value="true" /></td></tr>
-				<!-- ImageMagick only -->
-				<tr><td><div style="text-align:right">startPage</div></td><td><input type="text" name="startPage" /></td></tr>
-				<tr><td><div style="text-align:right">endPage</div></td><td><input type="text" name="endPage" /></td></tr>
-				<tr><td><div style="text-align:right">alphaRemove</div></td><td><input type="text" name="alphaRemove" /></td></tr>
-				<tr><td><div style="text-align:right">autoOrient</div></td><td><input type="text" name="autoOrient" /></td></tr>
-				<tr><td><div style="text-align:right">cropGravity</div></td><td><input type="text" name="cropGravity" />North, NorthEast...Center</td></tr>
-                <tr><td><div style="text-align:right">cropWidth</div></td><td><input type="text" name="cropWidth" /></td></tr>
-				<tr><td><div style="text-align:right">cropHeight</div></td><td><input type="text" name="cropHeight" /></td></tr>
-				<tr><td><div style="text-align:right">cropPercentage</div></td><td><input type="checkbox" name="cropPercentage" value="true" /></td></tr>
-				<tr><td><div style="text-align:right">cropXOffset</div></td><td><input type="text" name="cropXOffset" /></td></tr>
-				<tr><td><div style="text-align:right">cropYOffset</div></td><td><input type="text" name="cropYOffset" /></td></tr>
-				<tr><td><div style="text-align:right">thumbnail</div></td><td><input type="checkbox" name="thumbnail" value="true" /></td></tr>
-				<tr><td><div style="text-align:right">resizeWidth</div></td><td><input type="text" name="resizeWidth" value="" /></td></tr>
-				<tr><td><div style="text-align:right">resizeHeight</div></td><td><input type="text" name="resizeHeight" value="" /></td></tr>
-				<tr><td><div style="text-align:right">resizePercentage</div></td><td><input type="checkbox" name="resizePercentage" value="true" /></td></tr>
-				<tr><td><div style="text-align:right">allowEnlargement</div></td><td><input type="checkbox" name="allowEnlargement" value="true" /></td></tr>
-				<tr><td><div style="text-align:right">maintainAspectRatio</div></td><td><input type="checkbox" name="maintainAspectRatio" value="true" /></td></tr>
 
-				<tr><td></td><td><input type="submit" value="Transform" /></td></tr>
-            </table>
-        </form>
-	</div>
-	<div>
-        <a href="/log">Log entries</a>
-    </div>
+<body>
 	<div class="transfomer">
 		<h2>Tika Test Transformations</h2>
         <form method="POST" enctype="multipart/form-data" action="/transform">
             <table>
                 <tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr>
-                <tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" value="application/msword" /></td></tr>
-                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" value="txt" /></td></tr>
-                <tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" value="text/plain" /></td></tr>
-                <tr><td><div style="text-align:right">targetEncoding *</div></td><td><input type="text" name="targetEncoding" value="UTF-8" /></td></tr>
+                <tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="application/msword" /></td></tr>
+				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
+				<tr><td><div style="text-align:right">sourceExtension </div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
+				<tr><td><div style="text-align:right">targetExtension</div></td><td><input type="text" name="targetExtension" value="txt" /></td></tr>
+				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
+				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
+                <tr><td><div style="text-align:right">targetEncoding</div></td><td><input type="text" name="targetEncoding" value="UTF-8" /></td></tr>
                 <tr><td><div style="text-align:right">includeContents (archive) *</div></td><td><input type="checkbox" name="includeContents" value="true" /></td></tr>
-                <tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
-                <tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
 				<tr><td><div style="text-align:right">notExtractBookmarksText</div></td><td><input type="checkbox" name="notExtractBookmarksText" value="true" /></td></tr>
 				<tr><td></td><td><input type="submit" value="Transform" /></td></tr>
             </table>
@@ -74,9 +34,10 @@
 		<form method="POST" enctype="multipart/form-data" action="/transform">
 			<table>
                 <tr><td><div style="text-align:right">file *</div></td><td><input type="file" required="required" name="file" /></td></tr>
-                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" required="required" value="png" /></td></tr>
-				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
 				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="text/html" /></td></tr>
+				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
+				<tr><td><div style="text-align:right">sourceExtension </div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
+                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" required="required" value="png" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
 
@@ -89,9 +50,10 @@
 		<form method="POST" enctype="multipart/form-data" action="/transform">
 			<table>
                 <tr><td><div style="text-align:right">file *</div></td><td><input type="file" required="required" name="file" /></td></tr>
-				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="" /></td></tr>
 				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="" /></td></tr>
-				<tr><td><div style="text-align:right">targetExtension</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
+				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="" /></td></tr>
+				<tr><td><div style="text-align:right">sourceExtension </div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
+				<tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" required="required" value="" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
 
@@ -113,12 +75,13 @@
                 <tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr>
 				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="text/html" /></td></tr>
 				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
-				<tr><td><div style="text-align:right">sourceExtension</div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
-                <tr><td><div style="text-align:right">targetExtension</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
-				<tr><td><div style="text-align:right">sourceEncoding</div></td><td><input type="text" name="sourceEncoding" value="" /></td></tr>
-				<tr><td><div style="text-align:right">targetEncoding</div></td><td><input type="text" name="targetEncoding" value="" /></td></tr>
+				<tr><td><div style="text-align:right">sourceExtension </div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
+                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" required="required" value="" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
+				<tr><td><div style="text-align:right">sourceEncoding</div></td><td><input type="text" name="sourceEncoding" value="" /></td></tr>
+				<tr><td><div style="text-align:right">targetEncoding</div></td><td><input type="text" name="targetEncoding" value="" /></td></tr>
+
 
 
 				<tr><td></td><td><input type="submit" value="Transform" /></td></tr>
@@ -131,9 +94,10 @@
 		<form method="POST" enctype="multipart/form-data" action="/transform">
 			<table>
                 <tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr>
-				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
 				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="text/html" /></td></tr>
-                <tr><td><div style="text-align:right">targetExtension</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
+				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
+				<tr><td><div style="text-align:right">sourceExtension </div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
+                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" required="required" value="" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
 
@@ -143,7 +107,7 @@
 				<tr><td><div style="text-align:right">alphaRemove</div></td><td><input type="text" name="alphaRemove" /></td></tr>
 				<tr><td><div style="text-align:right">autoOrient</div></td><td><input type="text" name="autoOrient" /></td></tr>
 
-				<tr><td><div style="text-align:right">cropGravity</div></td><td><input type="text" name="cropGravity" />North, NorthEast...Center</td></tr>
+				<tr><td><div style="text-align:right">cropGravity</div></td><td><input type="text" name="cropGravity" value="North, NorthEast...Center"/></td></tr>
                 <tr><td><div style="text-align:right">cropWidth</div></td><td><input type="text" name="cropWidth" /></td></tr>
 				<tr><td><div style="text-align:right">cropHeight</div></td><td><input type="text" name="cropHeight" /></td></tr>
 				<tr><td><div style="text-align:right">cropPercentage</div></td><td><input type="checkbox" name="cropPercentage" value="true" /></td></tr>
@@ -160,6 +124,10 @@
 				<tr><td></td><td><input type="submit" value="Transform" /></td></tr>
 			</table>
 		</form>
+	</div>
+
+	<div style="display: inline-block;">
+		<a href="/log">Log entries</a>
 	</div>
 
     

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/resources/templates/transformForm.html
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/resources/templates/transformForm.html
@@ -73,8 +73,10 @@
         <h2>LibreOffice Test Transformation</h2>
 		<form method="POST" enctype="multipart/form-data" action="/transform">
 			<table>
-                <tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr>
-                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
+                <tr><td><div style="text-align:right">file *</div></td><td><input type="file" required="required" name="file" /></td></tr>
+                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" required="required" value="png" /></td></tr>
+				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
+				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="text/html" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
 
@@ -86,8 +88,10 @@
         <h2>Alfresco PDF Renderer Test Transformation</h2>
 		<form method="POST" enctype="multipart/form-data" action="/transform">
 			<table>
-                <tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr>
-                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
+                <tr><td><div style="text-align:right">file *</div></td><td><input type="file" required="required" name="file" /></td></tr>
+				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="" /></td></tr>
+				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="" /></td></tr>
+				<tr><td><div style="text-align:right">targetExtension</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
 
@@ -107,12 +111,12 @@
 		<form method="POST" enctype="multipart/form-data" action="/transform">
 			<table>
                 <tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr>
-				<tr><td><div style="text-align:right">sourceExtension *</div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
-                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
-				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" value="" /></td></tr>
-				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" value="" /></td></tr>
-				<tr><td><div style="text-align:right">sourceEncoding *</div></td><td><input type="text" name="sourceEncoding" value="" /></td></tr>
-				<tr><td><div style="text-align:right">targetEncoding *</div></td><td><input type="text" name="targetEncoding" value="" /></td></tr>
+				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="text/html" /></td></tr>
+				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
+				<tr><td><div style="text-align:right">sourceExtension</div></td><td><input type="text" name="sourceExtension" value="" /></td></tr>
+                <tr><td><div style="text-align:right">targetExtension</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
+				<tr><td><div style="text-align:right">sourceEncoding</div></td><td><input type="text" name="sourceEncoding" value="" /></td></tr>
+				<tr><td><div style="text-align:right">targetEncoding</div></td><td><input type="text" name="targetEncoding" value="" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
 
@@ -127,7 +131,9 @@
 		<form method="POST" enctype="multipart/form-data" action="/transform">
 			<table>
                 <tr><td><div style="text-align:right">file *</div></td><td><input type="file" name="file" /></td></tr>
-                <tr><td><div style="text-align:right">targetExtension *</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
+				<tr><td><div style="text-align:right">targetMimetype *</div></td><td><input type="text" name="targetMimetype" required="required" value="text/plain" /></td></tr>
+				<tr><td><div style="text-align:right">sourceMimetype *</div></td><td><input type="text" name="sourceMimetype" required="required" value="text/html" /></td></tr>
+                <tr><td><div style="text-align:right">targetExtension</div></td><td><input type="text" name="targetExtension" value="" /></td></tr>
 				<tr><td><div style="text-align:right">timeout</div></td><td><input type="text" name="timeout" value="" /></td></tr>
 				<tr><td><div style="text-align:right">testDelay</div></td><td><input type="text" name="testDelay" value="" /></td></tr>
 


### PR DESCRIPTION
Issues related to HTML test form tidy-up:

- Alfresco PDF Renderer Test Transformation is missing targetMimetype field
- LibreOffice Test Transformation is missing sourceMimetype field
- Miscellaneous Transformers Test Transformation only fields like sourceMimetype and targetMimetype are required, but all fields are marked as required
- ImageMagick Test Transformation missing targetMimetype and sourceMimetype