### PR TITLE
ATS-707: add transformName override

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
@@ -73,7 +73,9 @@ public class AIOController extends AbstractTransformerController
 
     // This property can be sent by acs repository's legacy transformers to force a transform,
     // instead of letting this T-Engine determine it based on the request parameters.
-    // This allows clients to specify transform names as they appear in the engine config files.
+    // This allows clients to specify transform names as they appear in the engine config files, for example:
+    // imagemagick, libreoffice, PdfBox, TikaAuto, ....
+    // See ATS-731.
     @Deprecated
     private static final String TRANSFORM_NAME_PROPERTY = "transformName";
 

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
@@ -72,7 +72,9 @@ public class AIOController extends AbstractTransformerController
     private static final Logger logger = LoggerFactory.getLogger(AIOController.class);
 
     // This property can be sent by acs repository's legacy transformers to force a transform,
-    // instead of letting this T-Engine determine it based on the request parameters
+    // instead of letting this T-Engine determine it based on the request parameters.
+    // This allows clients to specify transform names as they appear in the engine config files.
+    @Deprecated
     private static final String TRANSFORM_NAME_PROPERTY = "transformName";
 
     @Autowired

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
@@ -71,6 +71,10 @@ public class AIOController extends AbstractTransformerController
 {
     private static final Logger logger = LoggerFactory.getLogger(AIOController.class);
 
+    // This property can be sent by acs repository's legacy transformers to force a transform,
+    // instead of letting this T-Engine determine it based on the request parameters
+    private static final String TRANSFORM_NAME_PROPERTY = "transformName";
+
     @Autowired
     private  AIOTransformRegistry transformRegistry;
 
@@ -122,14 +126,17 @@ public class AIOController extends AbstractTransformerController
         @RequestParam(TARGET_MIMETYPE) String targetMimetype,
         @RequestParam(TARGET_EXTENSION) String targetExtension,
         @RequestParam Map<String, String> requestParameters,
-        @RequestParam (value = TEST_DELAY, required = false) Long testDelay)
-    {
+        @RequestParam (value = TEST_DELAY, required = false) Long testDelay,
 
+        // The TRANSFORM_NAME_PROPERTY param allows ACS legacy transformers to specify which transform to use,
+        // It can be removed once legacy transformers are removed from ACS.
+        @RequestParam (value = TRANSFORM_NAME_PROPERTY, required = false) String requestTransformName)
+    {
         debugLogTransform("Request parameters: ", sourceMimetype, targetMimetype, targetExtension, requestParameters);
 
         //Remove all required parameters from request parameters to get the list of options
         List<String> optionsToFilter = Arrays.asList(SOURCE_EXTENSION, TARGET_EXTENSION, TARGET_MIMETYPE,
-                SOURCE_MIMETYPE, TEST_DELAY);
+                SOURCE_MIMETYPE, TEST_DELAY, TRANSFORM_NAME_PROPERTY);
         Map<String, String> transformOptions = new HashMap<>(requestParameters);
         transformOptions.keySet().removeAll(optionsToFilter);
         transformOptions.values().removeIf(v -> v.isEmpty());
@@ -140,7 +147,21 @@ public class AIOController extends AbstractTransformerController
         final File sourceFile = createSourceFile(request, sourceMultipartFile);
         final File targetFile = createTargetFile(request, targetFilename);
 
-        final String transform = getTransformerName(sourceFile, sourceMimetype, targetMimetype, transformOptions);
+        // Check if transformName was provided in the request (this can happen for ACS legacy transformers)
+        String transform = requestTransformName;
+        if (transform == null || transform.isEmpty())
+        {
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Using engine config to determine the transform name.");
+            }
+            transform = getTransformerName(sourceFile, sourceMimetype, targetMimetype, transformOptions);
+        }
+        else if (logger.isDebugEnabled())
+        {
+            logger.debug("Using transform name provided by the request.");
+        }
+
         debugLogTransform("Performing transform with parameters: ", sourceMimetype, targetMimetype,
                 targetExtension, transformOptions);
         transformInternal(transform, sourceFile, targetFile, sourceMimetype, targetMimetype, transformOptions);


### PR DESCRIPTION
* Provide a way for Legacy ACS transformers to specify the transform to perform, rather than letting the T-Engine to determine it using the engine config.