### PR TITLE
ACS-99: Update to most current Java Base Image (for OpenJDK 11.0.7 / CentOS 7)

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
@@ -5,7 +5,7 @@
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.1-openjdk-centos-7-72b88c6f1f4c
+FROM alfresco/alfresco-base-java:11.0.7-openjdk-centos-7-145f5d28c8ca
 
 ENV APACHE_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/Apache%202.0.txt
 

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 
-FROM alfresco/alfresco-base-java:11.0.1-openjdk-centos-7-72b88c6f1f4c
+FROM alfresco/alfresco-base-java:11.0.7-openjdk-centos-7-145f5d28c8ca
 
 ARG IMAGEMAGICK_VERSION=7.0.7-27
 

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/Dockerfile
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # LibreOffice is from The Document Foundation. See the license at https://www.libreoffice.org/download/license/ or in /libreoffice.txt.
 
-FROM alfresco/alfresco-base-java:11.0.1-openjdk-centos-7-72b88c6f1f4c
+FROM alfresco/alfresco-base-java:11.0.7-openjdk-centos-7-145f5d28c8ca
 
 ARG LIBREOFFICE_VERSION=6.3.5
 

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/Dockerfile
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/Dockerfile
@@ -1,6 +1,6 @@
 # Image provides a container in which to run miscellaneous transformations for Alfresco Content Services.
 
-FROM alfresco/alfresco-base-java:11.0.1-openjdk-centos-7-72b88c6f1f4c
+FROM alfresco/alfresco-base-java:11.0.7-openjdk-centos-7-145f5d28c8ca
 
 ENV APACHE_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/Apache%202.0.txt
 ENV JAVA_OPTS=""

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/Dockerfile
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.1-openjdk-centos-7-72b88c6f1f4c
+FROM alfresco/alfresco-base-java:11.0.7-openjdk-centos-7-145f5d28c8ca
 
 ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/1.1/alfresco-pdf-renderer-1.1-linux.tgz
 ENV PDFIUM_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/pdfium.txt

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tika is from Apache. See the license at http://www.apache.org/licenses/LICENSE-2.0.
 
-FROM alfresco/alfresco-base-java:11.0.1-openjdk-centos-7-72b88c6f1f4c
+FROM alfresco/alfresco-base-java:11.0.7-openjdk-centos-7-145f5d28c8ca
 
 ENV APACHE_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/Apache%202.0.txt
 ENV JAVA_OPTS=""


### PR DESCRIPTION
- note: aligns with ACS Repo 6.2.1-A4 and higher (note: post RC3)