### PR TITLE
ATS-777 / REPO-4334: Move metadata extraction into T-Engines

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
@@ -82,7 +82,7 @@ public class AIOController extends AbstractTransformerController
             {
                 Map<String, String> parameters = new HashMap<>();
                 parameters.put(SOURCE_ENCODING, "UTF-8");
-                transform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile);
+                processTransform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile, null);
             }
         };
     }
@@ -95,9 +95,17 @@ public class AIOController extends AbstractTransformerController
         return new ResponseEntity<>(transformConfig, OK);
     }
 
+    @Deprecated
+    public void processTransform(final File sourceFile, final File targetFile,
+                                 final String sourceMimetype, final String targetMimetype,
+                                 final Map<String, String> transformOptions, final Long timeout)
+    {
+        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
+    }
+
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
+                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
     {
         logger.debug("Processing transform with: transformName; '{}', sourceFile '{}', targetFile '{}', transformOptions" +
                 " {}", transformName, sourceFile, targetFile, transformOptions);

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
@@ -82,7 +82,7 @@ public class AIOController extends AbstractTransformerController
             {
                 Map<String, String> parameters = new HashMap<>();
                 parameters.put(SOURCE_ENCODING, "UTF-8");
-                processTransform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile, null);
+                transform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile);
             }
         };
     }
@@ -95,17 +95,9 @@ public class AIOController extends AbstractTransformerController
         return new ResponseEntity<>(transformConfig, OK);
     }
 
-    @Deprecated
-    public void processTransform(final File sourceFile, final File targetFile,
-                                 final String sourceMimetype, final String targetMimetype,
-                                 final Map<String, String> transformOptions, final Long timeout)
-    {
-        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
-    }
-
     @Override
-    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
-                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
+    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
+                             Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         logger.debug("Processing transform with: transformName; '{}', sourceFile '{}', targetFile '{}', transformOptions" +
                 " {}", transformName, sourceFile, targetFile, transformOptions);

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
@@ -82,7 +82,7 @@ public class AIOController extends AbstractTransformerController
             {
                 Map<String, String> parameters = new HashMap<>();
                 parameters.put(SOURCE_ENCODING, "UTF-8");
-                transform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile);
+                transformImpl("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile);
             }
         };
     }
@@ -96,8 +96,8 @@ public class AIOController extends AbstractTransformerController
     }
 
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
+                                 Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         logger.debug("Processing transform with: transformName; '{}', sourceFile '{}', targetFile '{}', transformOptions" +
                 " {}", transformName, sourceFile, targetFile, transformOptions);

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
@@ -110,7 +110,7 @@ public class  ImageMagickController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                processTransform(null, null, null, Collections.emptyMap(), sourceFile, targetFile, null);
+                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
             }
         };
     }
@@ -122,17 +122,9 @@ public class  ImageMagickController extends AbstractTransformerController
         return null; // does not matter what value is returned, as it is not used because there is only one.
     }
 
-    @Deprecated
-    public void processTransform(final File sourceFile, final File targetFile,
-                                 final String sourceMimetype, final String targetMimetype,
-                                 final Map<String, String> transformOptions, final Long timeout)
-    {
-        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
-    }
-
     @Override
-    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
-                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
+    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
+                             Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
@@ -110,7 +110,7 @@ public class  ImageMagickController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
+                processTransform(null, null, null, Collections.emptyMap(), sourceFile, targetFile, null);
             }
         };
     }
@@ -122,9 +122,17 @@ public class  ImageMagickController extends AbstractTransformerController
         return null; // does not matter what value is returned, as it is not used because there is only one.
     }
 
+    @Deprecated
+    public void processTransform(final File sourceFile, final File targetFile,
+                                 final String sourceMimetype, final String targetMimetype,
+                                 final Map<String, String> transformOptions, final Long timeout)
+    {
+        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
+    }
+
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
+                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
     {
         commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
@@ -110,7 +110,7 @@ public class  ImageMagickController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
+                transformImpl(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
             }
         };
     }
@@ -123,8 +123,8 @@ public class  ImageMagickController extends AbstractTransformerController
     }
 
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
+                                 Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
@@ -96,7 +96,7 @@ public class LibreOfficeController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
+                transformImpl(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
                 javaExecutor.call(sourceFile, targetFile);
             }
         };
@@ -110,8 +110,8 @@ public class LibreOfficeController extends AbstractTransformerController
     }
 
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
+                                 Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         javaExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
@@ -96,7 +96,7 @@ public class LibreOfficeController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
+                processTransform(null, null, null, Collections.emptyMap(), sourceFile, targetFile, null);
                 javaExecutor.call(sourceFile, targetFile);
             }
         };
@@ -109,9 +109,17 @@ public class LibreOfficeController extends AbstractTransformerController
         return null; // does not matter what value is returned, as it is not used because there is only one.
     }
 
+    @Deprecated
+    public void processTransform(final File sourceFile, final File targetFile,
+                                 final String sourceMimetype, final String targetMimetype,
+                                 final Map<String, String> transformOptions, final Long timeout)
+    {
+        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
+    }
+
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
+                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
     {
         javaExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
@@ -96,7 +96,7 @@ public class LibreOfficeController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                processTransform(null, null, null, Collections.emptyMap(), sourceFile, targetFile, null);
+                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
                 javaExecutor.call(sourceFile, targetFile);
             }
         };
@@ -109,17 +109,9 @@ public class LibreOfficeController extends AbstractTransformerController
         return null; // does not matter what value is returned, as it is not used because there is only one.
     }
 
-    @Deprecated
-    public void processTransform(final File sourceFile, final File targetFile,
-                                 final String sourceMimetype, final String targetMimetype,
-                                 final Map<String, String> transformOptions, final Long timeout)
-    {
-        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
-    }
-
     @Override
-    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
-                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
+    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
+                             Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         javaExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/main/java/org/alfresco/transformer/MiscController.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/main/java/org/alfresco/transformer/MiscController.java
@@ -74,22 +74,14 @@ public class MiscController extends AbstractTransformerController
             {
                 Map<String, String> parameters = new HashMap<>();
                 parameters.put(SOURCE_ENCODING, "UTF-8");
-                processTransform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile, null);
+                transform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile);
             }
         };
     }
 
-    @Deprecated
-    public void processTransform(final File sourceFile, final File targetFile,
-                                 final String sourceMimetype, final String targetMimetype,
-                                 final Map<String, String> transformOptions, final Long timeout)
-    {
-        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
-    }
-
     @Override
-    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
-                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
+    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
+                             Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
         transformer.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/main/java/org/alfresco/transformer/MiscController.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/main/java/org/alfresco/transformer/MiscController.java
@@ -74,14 +74,14 @@ public class MiscController extends AbstractTransformerController
             {
                 Map<String, String> parameters = new HashMap<>();
                 parameters.put(SOURCE_ENCODING, "UTF-8");
-                transform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile);
+                transformImpl("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile);
             }
         };
     }
 
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
+                                 Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
         transformer.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/main/java/org/alfresco/transformer/MiscController.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/main/java/org/alfresco/transformer/MiscController.java
@@ -74,14 +74,22 @@ public class MiscController extends AbstractTransformerController
             {
                 Map<String, String> parameters = new HashMap<>();
                 parameters.put(SOURCE_ENCODING, "UTF-8");
-                transform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile);
+                processTransform("html", MIMETYPE_HTML, MIMETYPE_TEXT_PLAIN, parameters, sourceFile, targetFile, null);
             }
         };
     }
 
+    @Deprecated
+    public void processTransform(final File sourceFile, final File targetFile,
+                                 final String sourceMimetype, final String targetMimetype,
+                                 final Map<String, String> transformOptions, final Long timeout)
+    {
+        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
+    }
+
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
+                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
     {
         transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
         transformer.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
@@ -97,7 +97,7 @@ public class AlfrescoPdfRendererController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                processTransform(null, null, null, Collections.emptyMap(), sourceFile, targetFile, null);
+                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
             }
         };
     }
@@ -109,17 +109,9 @@ public class AlfrescoPdfRendererController extends AbstractTransformerController
         return null; // does not matter what value is returned, as it is not used because there is only one.
     }
 
-    @Deprecated
-    public void processTransform(final File sourceFile, final File targetFile,
-                                 final String sourceMimetype, final String targetMimetype,
-                                 final Map<String, String> transformOptions, final Long timeout)
-    {
-        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
-    }
-
     @Override
-    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
-                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
+    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
+                             Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
@@ -97,7 +97,7 @@ public class AlfrescoPdfRendererController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
+                transformImpl(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
             }
         };
     }
@@ -110,8 +110,8 @@ public class AlfrescoPdfRendererController extends AbstractTransformerController
     }
 
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
+                                 Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
@@ -97,7 +97,7 @@ public class AlfrescoPdfRendererController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                transform(null, null, null, Collections.emptyMap(), sourceFile, targetFile);
+                processTransform(null, null, null, Collections.emptyMap(), sourceFile, targetFile, null);
             }
         };
     }
@@ -109,9 +109,17 @@ public class AlfrescoPdfRendererController extends AbstractTransformerController
         return null; // does not matter what value is returned, as it is not used because there is only one.
     }
 
+    @Deprecated
+    public void processTransform(final File sourceFile, final File targetFile,
+                                 final String sourceMimetype, final String targetMimetype,
+                                 final Map<String, String> transformOptions, final Long timeout)
+    {
+        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
+    }
+
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
+                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
     {
         commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
@@ -92,14 +92,14 @@ public class TikaController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                transform(PDF_BOX, MIMETYPE_PDF, MIMETYPE_TEXT_PLAIN, Collections.emptyMap(), sourceFile, targetFile);
+                transformImpl(PDF_BOX, MIMETYPE_PDF, MIMETYPE_TEXT_PLAIN, Collections.emptyMap(), sourceFile, targetFile);
             }
         };
     }
 
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
+                                 Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
         javaExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
@@ -92,14 +92,22 @@ public class TikaController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                transform(PDF_BOX, MIMETYPE_PDF, MIMETYPE_TEXT_PLAIN, Collections.emptyMap(), sourceFile, targetFile);
+                processTransform(PDF_BOX, MIMETYPE_PDF, MIMETYPE_TEXT_PLAIN, Collections.emptyMap(), sourceFile, targetFile, null);
             }
         };
     }
 
+    @Deprecated
+    public void processTransform(final File sourceFile, final File targetFile,
+                                 final String sourceMimetype, final String targetMimetype,
+                                 final Map<String, String> transformOptions, final Long timeout)
+    {
+        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
+    }
+
     @Override
-    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
-                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
+                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
     {
         transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
         javaExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
@@ -92,22 +92,14 @@ public class TikaController extends AbstractTransformerController
             @Override
             protected void executeTransformCommand(File sourceFile, File targetFile)
             {
-                processTransform(PDF_BOX, MIMETYPE_PDF, MIMETYPE_TEXT_PLAIN, Collections.emptyMap(), sourceFile, targetFile, null);
+                transform(PDF_BOX, MIMETYPE_PDF, MIMETYPE_TEXT_PLAIN, Collections.emptyMap(), sourceFile, targetFile);
             }
         };
     }
 
-    @Deprecated
-    public void processTransform(final File sourceFile, final File targetFile,
-                                 final String sourceMimetype, final String targetMimetype,
-                                 final Map<String, String> transformOptions, final Long timeout)
-    {
-        processTransform(null, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
-    }
-
     @Override
-    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
-                                    Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
+    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
+                             Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
         javaExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -87,7 +87,9 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 import static org.springframework.util.StringUtils.getFilenameExtension;
 
 /**
- * <p>Abstract Controller, provides structure and helper methods to sub-class transformer controllers.</p>
+ * <p>Abstract Controller, provides structure and helper methods to sub-class transformer controllers. Sub classes
+ * should implement {@link #transform(String, String, String, Map, File, File)} and unimplemented methods from
+ * {@link TransformController}.</p>
  *
  * <p>Status Codes:</p>
  * <ul>
@@ -484,6 +486,20 @@ public abstract class AbstractTransformerController implements TransformControll
         return transformOptions;
     }
 
-    protected abstract void transform(String transformName, String sourceMimetype, String targetMimetype,
-                                      Map<String, String> transformOptions, File sourceFile, File targetFile);
+    /**
+     * Normally overridden in subclasses to initiate the transformation.
+     *
+     * @param transformName the name of the transformer in the engine_config.json file
+     * @param sourceMimetype mimetype of the source
+     * @param targetMimetype mimetype of the target
+     * @param transformOptions transform options from the client
+     * @param sourceFile the source file
+     * @param targetFile the target file
+     */
+    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
+                             Map<String, String> transformOptions, File sourceFile, File targetFile)
+    {
+        throw new IllegalStateException("This method should be overridden if you have not overridden " +
+                "transform(HttpServletRequest...) and processTransform(...)");
+    }
 }

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -88,7 +88,7 @@ import static org.springframework.util.StringUtils.getFilenameExtension;
 
 /**
  * <p>Abstract Controller, provides structure and helper methods to sub-class transformer controllers. Sub classes
- * should implement {@link #processTransform(String, String, String, Map, File, File, Long)} and unimplemented methods from
+ * should implement {@link #transform(String, String, String, Map, File, File)} and unimplemented methods from
  * {@link TransformController}.</p>
  *
  * <p>Status Codes:</p>
@@ -170,7 +170,7 @@ public abstract class AbstractTransformerController implements TransformControll
 
         Map<String, String> transformOptions = getTransformOptions(requestParameters);
         String transformName = getTransformerName(sourceMimetype, targetMimetype, requestTransformName, sourceFile, transformOptions);
-        processTransform(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, null);
+        transform(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
 
         final ResponseEntity<Resource> body = createAttachment(targetFilename, targetFile);
         LogEntry.setTargetSize(targetFile.length());
@@ -266,12 +266,8 @@ public abstract class AbstractTransformerController implements TransformControll
         // Run the transformation
         try
         {
-            String sourceMimetype = request.getSourceMediaType();
-            String targetMimetype = request.getTargetMediaType();
-            Map<String, String> transformOptions = request.getTransformRequestOptions();
-
-            String transformName = getTransformerName(sourceFile, sourceMimetype, targetMimetype, transformOptions);
-            processTransform(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile, timeout);
+            processTransform(sourceFile, targetFile, request.getSourceMediaType(),
+                request.getTargetMediaType(), request.getTransformRequestOptions(), timeout);
         }
         catch (TransformException e)
         {
@@ -409,6 +405,21 @@ public abstract class AbstractTransformerController implements TransformControll
         return sb.toString();
     }
 
+    public void processTransform(final File sourceFile, final File targetFile,
+                                  final String sourceMimetype, final String targetMimetype,
+                                  final Map<String, String> transformOptions, final Long timeout)
+    {
+        if (logger.isDebugEnabled())
+        {
+            logger.debug(
+                    "Processing request with: sourceFile '{}', targetFile '{}', transformOptions" +
+                            " '{}', timeout {} ms", sourceFile, targetFile, transformOptions, timeout);
+        }
+
+        String transformName = getTransformerName(sourceFile, sourceMimetype, targetMimetype, transformOptions);
+        transform(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+    }
+
     private String getTransformerName(String sourceMimetype, String targetMimetype,
                                       String requestTransformName, File sourceFile,
                                       Map<String, String> transformOptions)
@@ -476,29 +487,6 @@ public abstract class AbstractTransformerController implements TransformControll
     }
 
     /**
-     * Deprecated: for backwards compatibility with T-Engine 2.1.0 - 2.2.2.
-     *
-     * Transformers should *Override* the implementation of:
-     *
-     * processTransform(String transformName, String sourceMimetype, String targetMimetype,
-     *                  Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
-     *
-     * @param sourceFile
-     * @param targetFile
-     * @param sourceMimetype
-     * @param targetMimetype
-     * @param transformOptions
-     * @param timeout
-     */
-    @Deprecated
-    public void processTransform(final File sourceFile, final File targetFile,
-                                 final String sourceMimetype, final String targetMimetype,
-                                 final Map<String, String> transformOptions, final Long timeout)
-    {
-        throw new IllegalArgumentException("Deprecated - new implementations should override other processTransform method !");
-    }
-
-    /**
      * Normally overridden in subclasses to initiate the transformation.
      *
      * @param transformName the name of the transformer in the engine_config.json file
@@ -508,16 +496,10 @@ public abstract class AbstractTransformerController implements TransformControll
      * @param sourceFile the source file
      * @param targetFile the target file
      */
-    public void processTransform(String transformName, String sourceMimetype, String targetMimetype,
-                                 Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout)
+    protected void transform(String transformName, String sourceMimetype, String targetMimetype,
+                             Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
-        if (logger.isDebugEnabled())
-        {
-            logger.debug("Processing request with: sourceFile '{}', targetFile '{}', transformOptions" +
-                    " '{}', timeout {} ms", sourceFile, targetFile, transformOptions, timeout);
-        }
-
-        // for backwards-compatibility only for older T-Engines that have overridden other *deprecated* processTransform method !
-        processTransform(sourceFile, targetFile, sourceMimetype, targetMimetype, transformOptions, timeout);
+        throw new IllegalStateException("This method should be overridden if you have not overridden " +
+                "transform(HttpServletRequest...) and processTransform(...)");
     }
 }

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/TransformController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/TransformController.java
@@ -65,9 +65,13 @@ public interface TransformController
 
     ResponseEntity<TransformReply> transform(TransformRequest transformRequest, Long timeout);
 
+    @Deprecated
     void processTransform(final File sourceFile, final File targetFile,
         final String sourceMimetype, final String targetMimetype,
         final Map<String, String> transformOptions, final Long timeout);
+
+    void processTransform(String transformName, String sourceMimetype, String targetMimetype,
+                          Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout);
 
     String getTransformerName();
 

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/TransformController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/TransformController.java
@@ -65,13 +65,9 @@ public interface TransformController
 
     ResponseEntity<TransformReply> transform(TransformRequest transformRequest, Long timeout);
 
-    @Deprecated
     void processTransform(final File sourceFile, final File targetFile,
         final String sourceMimetype, final String targetMimetype,
         final Map<String, String> transformOptions, final Long timeout);
-
-    void processTransform(String transformName, String sourceMimetype, String targetMimetype,
-                          Map<String, String> transformOptions, File sourceFile, File targetFile, Long timeout);
 
     String getTransformerName();
 


### PR DESCRIPTION
- Added a default implementation of AbstractTransformerController#transform(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String,java.lang.String>, java.io.File, java.io.File) for existing
T-Engines that override transform(HttpServletRequest...) and processTransform(...).

I would get rid of the code duplication in alfresco-ai-transformers. There is some rework required in its' test class mocking anyway. From the log: "There is already 'aiController' bean method ... transform(". The test code appear to assume there can be only be one method called transform. This is no longer the case. I'm guessing it is a small fix for someone with the AWS dev env set up, so it might make sense to fix up the code duplication at the same time.