### PR TITLE
ATS-816: Fix tika apple keynote

### DIFF
--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaTransformationIT.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaTransformationIT.java
@@ -104,7 +104,7 @@ public class TikaTransformationIT
                 Stream.of(
                     Triple.of("quick.key", "html", "application/vnd.apple.keynote"),
                     // Does not work, alfresco-docker-sourceMimetype-misc can handle this target mimetype, removed from engine_config.json
-                    // Triple.of("quick.key", "txt", "TikaAuto"),
+                     Triple.of("quick.key", "txt", "application/vnd.apple.keynote"),
                     Triple.of("quick.key", "xhtml", "application/vnd.apple.keynote"),
                     Triple.of("quick.key", "xml", "application/vnd.apple.keynote")
                 ),

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/resources/tika-config.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/resources/tika-config.xml
@@ -5,6 +5,10 @@
     <service-loader initializableProblemHandler="ignore"/>
 
     <parsers>
+        <!-- Default Parser for most things, except application/vnd.apple.keynote.13, which is handled by PackageParser -->
+        <parser class="org.apache.tika.parser.DefaultParser">
+            <mime-exclude>application/vnd.apple.keynote.13</mime-exclude>
+        </parser>
         <!-- ATS-816: Use the PackageParser for application/vnd.apple.keynote.13 as that was used in tika-1.21-20190624-alfresco-patched -->
         <parser class="org.apache.tika.parser.pkg.PackageParser">
             <mime>application/vnd.apple.keynote.13</mime>

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/resources/tika-config.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/resources/tika-config.xml
@@ -3,4 +3,11 @@
     <!-- This property, when set, will hide the start up warnings of tika for libraries are missing. -->
     <!-- See https://issues.apache.org/jira/browse/TIKA-2490 -->
     <service-loader initializableProblemHandler="ignore"/>
+
+    <parsers>
+        <!-- ATS-816: Use the PackageParser for application/vnd.apple.keynote.13 as that was used in tika-1.21-20190624-alfresco-patched -->
+        <parser class="org.apache.tika.parser.pkg.PackageParser">
+            <mime>application/vnd.apple.keynote.13</mime>
+        </parser>
+    </parsers>
 </properties>

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/resources/tika-config.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/resources/tika-config.xml
@@ -5,13 +5,11 @@
     <service-loader initializableProblemHandler="ignore"/>
 
     <parsers>
-        <!-- Default Parser for most things, except application/vnd.apple.keynote.13, which is handled by PackageParser -->
-        <parser class="org.apache.tika.parser.DefaultParser">
-            <mime-exclude>application/vnd.apple.keynote.13</mime-exclude>
-        </parser>
         <!-- ATS-816: Use the PackageParser for application/vnd.apple.keynote.13 as that was used in tika-1.21-20190624-alfresco-patched -->
         <parser class="org.apache.tika.parser.pkg.PackageParser">
             <mime>application/vnd.apple.keynote.13</mime>
         </parser>
+        <!-- Default parser needs to be included if the PackageParser parser is specified here, otherwise just the PackageParser is added-->
+        <parser class="org.apache.tika.parser.DefaultParser"/>
     </parsers>
 </properties>


### PR DESCRIPTION
The application/vnd.apple.keynote -> text/plain transformation has been found to fail after switching a new version of tika in ATS-801
The previous version of tika would use a org.apache.tika.parser.pkg.PackageParser but the new version uses an empty parser producing an empty target file, which now causes test failures in the new ATS integration tests.