### PR TITLE
Add Alfresco Releases Nexus Repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,20 @@
         </dependencies>
     </dependencyManagement>
 
+    <repositories>
+        <repository>
+            <id>alfresco-releases</id>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <name>Alfresco Releases</name>
+            <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
+        </repository>
+    </repositories>
+
     <distributionManagement>
         <snapshotRepository>
             <id>alfresco-public-snapshots</id>


### PR DESCRIPTION
I was trying to build:

https://github.com/Alfresco/alfresco-transform-core

locally, but failed with this error:

The POM for org.alfresco:alfresco-transform-model:jar:1.0.2.11 is missing, no dependency information available