### PR TITLE
ATS-829  Release T-Engines 2.3.6

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.alfresco.transformer.util.RequestParamMap.PAGE_LIMIT;
 import static org.alfresco.transformer.util.RequestParamMap.TRANSFORM_NAME_PARAMETER;
@@ -97,7 +98,7 @@ public class AIOTransformRegistryTest
                 "Archive", "OutlookMsg", "PdfBox", "Office", "Poi", "OOXML", "TikaAuto", "TextMining");
 
         List<String> expectedTransformOptionNames = Arrays.asList("tikaOptions", "archiveOptions", "pdfboxOptions",
-                "textToPdfOptions", "stringOptions");
+                "textToPdfOptions", "stringOptions", "metadataOptions");
 
         TransformConfig miscConfig = loadConfig("misc_engine_config.json");
         TransformConfig tikaConfig = loadConfig("tika_engine_config.json");
@@ -116,8 +117,11 @@ public class AIOTransformRegistryTest
         }
 
         // check correct number of options
+        long distinctOptionCount = Stream.concat(
+                miscConfig.getTransformOptions().keySet().stream(),
+                tikaConfig.getTransformOptions().keySet().stream()).distinct().count();
         assertEquals("Number of expected transformers",
-                miscConfig.getTransformOptions().size() + tikaConfig.getTransformOptions().size(),
+                distinctOptionCount,
                 aioTransformerRegistry.getTransformConfig().getTransformOptions().size());
 
         Set<String> actualOptionNames = aioTransformerRegistry.getTransformConfig().getTransformOptions().keySet();
@@ -125,7 +129,7 @@ public class AIOTransformRegistryTest
         // check all options are there
         for (String optionName : expectedTransformOptionNames)
         {
-            assertTrue("Expected transform option missing.",  actualOptionNames.contains(optionName));
+            assertTrue("Expected transform option missing:"+optionName,  actualOptionNames.contains(optionName));
         }
     }
 

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/resources/misc_engine_config.json
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/resources/misc_engine_config.json
@@ -5,6 +5,9 @@
     ],
     "stringOptions": [
       {"value": {"name": "targetEncoding"}}
+    ],
+    "metadataOptions": [
+      {"value": {"name": "extractMapping"}}
     ]
   },
   "transformers": [
@@ -77,6 +80,7 @@
         {"sourceMediaType": "application/xhtml+xml",                         "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -85,6 +89,7 @@
         {"sourceMediaType": "message/rfc822",                                "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     }
   ]

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/resources/tika_engine_config.json
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/resources/tika_engine_config.json
@@ -10,6 +10,9 @@
     "pdfboxOptions": [
       {"value": {"name": "notExtractBookmarksText"}},
       {"value": {"name": "targetEncoding"}}
+    ],
+    "metadataOptions": [
+      {"value": {"name": "extractMapping"}}
     ]
   },
   "transformers": [
@@ -520,6 +523,7 @@
         {"sourceMediaType": "image/x-dwg",                                                                "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -528,6 +532,7 @@
         {"sourceMediaType": "application/vnd.ms-outlook",                                                 "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -536,6 +541,7 @@
         {"sourceMediaType": "audio/mpeg",                                                                 "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -556,6 +562,7 @@
         {"sourceMediaType": "application/x-tika-ooxml-protected",                                         "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -601,6 +608,7 @@
         {"sourceMediaType": "application/x-vnd.oasis.opendocument.graphics",                              "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -610,6 +618,7 @@
         {"sourceMediaType": "application/illustrator",                                                    "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -645,6 +654,7 @@
         {"sourceMediaType": "application/vnd.ms-excel.template.macroenabled.12",                          "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -662,6 +672,7 @@
         {"sourceMediaType": "video/mp4",                                                                  "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -968,6 +979,7 @@
         {"sourceMediaType": "image/hfa",                                                                  "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     }
   ]

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -150,6 +150,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_TEXT_PLAIN,
             null,
             null,
+            null,
             readTestFile("eml"));
         assertTrue("Content from eml transform didn't contain expected value. ",
             result.getResponse().getContentAsString().contains(expected));
@@ -169,7 +170,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_TEXT_PLAIN,
             null,
             null,
-            readTestFile("spanish.eml"));
+                null, readTestFile("spanish.eml"));
 
         String contentResult = new String(result.getResponse().getContentAsByteArray(), UTF_8);
         assertTrue("Content from eml transform didn't contain expected value. ",
@@ -189,6 +190,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_RFC822,
             "txt",
             MIMETYPE_TEXT_PLAIN,
+            null,
             null,
             null,
             readTestFile("attachment.eml"));
@@ -211,6 +213,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_TEXT_PLAIN,
             null,
             null,
+            null,
             readTestFile("alternative.eml"));
         assertTrue("Content from eml transform didn't contain expected value. ",
             result.getResponse().getContentAsString().contains(expected));
@@ -230,9 +233,75 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_TEXT_PLAIN,
             null,
             null,
+            null,
             readTestFile("nested.alternative.eml"));
         assertTrue("Content from eml transform didn't contain expected value. ",
             result.getResponse().getContentAsString().contains(expected));
+    }
+
+    /**
+     * Test extracting default metadata from a valid eml file
+     */
+    @Test
+    public void testExtractMetadataRFC822() throws Exception
+    {
+        String expected =
+                "{\"{http://www.alfresco.org/model/content/1.0}addressee\":\"Nevin Nollop <nevin.nollop@gmail.com>\"," +
+                        "\"{http://www.alfresco.org/model/content/1.0}description\":\"The quick brown fox jumps over the lazy dog\"," +
+                        "\"{http://www.alfresco.org/model/content/1.0}addressees\":\"Nevin Nollop <nevinn@alfresco.com>\"," +
+                        "\"{http://www.alfresco.org/model/imap/1.0}dateSent\":1086351802000," +
+                        "\"{http://www.alfresco.org/model/imap/1.0}messageTo\":\"Nevin Nollop <nevin.nollop@gmail.com>\"," +
+                        "\"{http://www.alfresco.org/model/imap/1.0}messageId\":\"<20040604122322.GV1905@phoenix.home>\"," +
+                        "\"{http://www.alfresco.org/model/content/1.0}title\":\"The quick brown fox jumps over the lazy dog\"," +
+                        "\"{http://www.alfresco.org/model/imap/1.0}messageSubject\":\"The quick brown fox jumps over the lazy dog\"," +
+                        "\"{http://www.alfresco.org/model/imap/1.0}messageCc\":\"Nevin Nollop <nevinn@alfresco.com>\"," +
+                        "\"{http://www.alfresco.org/model/content/1.0}sentdate\":1086351802000," +
+                        "\"{http://www.alfresco.org/model/content/1.0}subjectline\":\"The quick brown fox jumps over the lazy dog\"," +
+                        "\"{http://www.alfresco.org/model/imap/1.0}messageFrom\":\"Nevin Nollop <nevin.nollop@alfresco.com>\"," +
+                        "\"{http://www.alfresco.org/model/content/1.0}originator\":\"Nevin Nollop <nevin.nollop@alfresco.com>\"}";
+        MvcResult result = sendRequest("eml",
+                null,
+                MIMETYPE_RFC822,
+                "json",
+                "alfresco-metadata-extract",
+                null,
+                null,
+                null,
+                readTestFile("eml"));
+        String metadata = result.getResponse().getContentAsString();
+        assertEquals("Metadata extract", expected, metadata);
+    }
+
+    /**
+     * Test extracting metadata specified in an option from a valid eml file
+     */
+    @Test
+    public void testExtractMetadataOptionRFC822() throws Exception
+    {
+        // {"messageSubject":["{http://www.alfresco.org/model/imap/1.0}messageSubject","{http://www.alfresco.org/model/content/1.0}subjectline","{http://www.alfresco.org/model/content/1.0}description","{http://www.alfresco.org/model/content/1.0}title"],"Thread-Index":["{http://www.alfresco.org/model/imap/1.0}threadIndex"],"messageTo":["{http://www.alfresco.org/model/imap/1.0}messageTo","{http://www.alfresco.org/model/content/1.0}addressee"],"messageSent":["{http://www.alfresco.org/model/content/1.0}sentdate","{http://www.alfresco.org/model/imap/1.0}dateSent"],"Message-ID":["{http://www.alfresco.org/model/imap/1.0}messageId"],"messageCc":["{http://www.alfresco.org/model/imap/1.0}messageCc","{http://www.alfresco.org/model/content/1.0}addressees"],"messageReceived":["{http://www.alfresco.org/model/imap/1.0}dateReceived"],"messageFrom":["{http://www.alfresco.org/model/imap/1.0}messageFrom","{http://www.alfresco.org/model/content/1.0}originator"]}
+        String extractMapping =
+                "{\"messageSubject\":[" +
+                    "\"{http://www.alfresco.org/model/imap/1.0}messageSubject\"," +
+                    "\"{http://www.alfresco.org/model/content/1.0}title\"]," +
+                "\"Thread-Index\":[" +
+                    "\"{http://www.alfresco.org/model/imap/1.0}threadIndex\"]," +
+                "\"messageFrom\":[" +
+                    "\"{http://www.alfresco.org/model/dod5015/1.0}dodProp1\"]}\n";
+        String expected =
+                "{\"{http://www.alfresco.org/model/imap/1.0}messageSubject\":\"The quick brown fox jumps over the lazy dog\"," +
+                 "\"{http://www.alfresco.org/model/dod5015/1.0}dodProp1\":\"Nevin Nollop <nevin.nollop@alfresco.com>\"," +
+                 "\"{http://www.alfresco.org/model/content/1.0}title\":\"The quick brown fox jumps over the lazy dog\"}";
+        MvcResult result = sendRequest("eml",
+                null,
+                MIMETYPE_RFC822,
+                "json",
+                "alfresco-metadata-extract",
+                null,
+                null,
+                extractMapping,
+                readTestFile("eml"));
+        String metadata = result.getResponse().getContentAsString();
+        assertEquals("Option metadata extract", expected, metadata);
     }
 
     /**
@@ -247,6 +316,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_RFC822,
             "txt",
             MIMETYPE_TEXT_PLAIN,
+            null,
             null,
             null,
             readTestFile("htmlChars.eml"));
@@ -273,6 +343,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_HTML,
             "txt",
             MIMETYPE_TEXT_PLAIN,
+            null,
             null,
             null,
             expected.getBytes());
@@ -304,6 +375,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_TEXT_PLAIN,
             "UTF-8",
             null,
+            null,
             content);
 
         String contentResult = new String(result.getResponse().getContentAsByteArray(),
@@ -323,6 +395,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             "txt",
             MIMETYPE_TEXT_PLAIN,
             "UTF-8",
+            null,
             null,
             content);
 
@@ -349,6 +422,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             MIMETYPE_PDF,
             null,
             "1",
+            null,
             expected.getBytes());
 
         // Read back in the PDF and check it
@@ -368,7 +442,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
     public void testAppleIWorksPages() throws Exception
     {
         MvcResult result = sendRequest("numbers", null, MIMETYPE_IWORK_NUMBERS,
-            "jpeg", MIMETYPE_IMAGE_JPEG, null, null, readTestFile("pages"));
+            "jpeg", MIMETYPE_IMAGE_JPEG, null, null, null, readTestFile("pages"));
         assertTrue("Expected image content but content is empty.",
             result.getResponse().getContentLengthLong() > 0L);
     }
@@ -377,7 +451,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
     public void testAppleIWorksNumbers() throws Exception
     {
         MvcResult result = sendRequest("numbers", null, MIMETYPE_IWORK_NUMBERS,
-            "jpeg", MIMETYPE_IMAGE_JPEG, null, null, readTestFile("numbers"));
+            "jpeg", MIMETYPE_IMAGE_JPEG, null, null, null, readTestFile("numbers"));
         assertTrue("Expected image content but content is empty.",
             result.getResponse().getContentLengthLong() > 0L);
     }
@@ -386,7 +460,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
     public void testAppleIWorksKey() throws Exception
     {
         MvcResult result = sendRequest("key", null, MIMETYPE_IWORK_KEYNOTE,
-            "jpeg", MIMETYPE_IMAGE_JPEG, null, null, readTestFile("key"));
+            "jpeg", MIMETYPE_IMAGE_JPEG, null, null, null, readTestFile("key"));
         assertTrue("Expected image content but content is empty.",
             result.getResponse().getContentLengthLong() > 0L);
     }
@@ -396,7 +470,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
     public void testOOXML() throws Exception
     {
         MvcResult result = sendRequest("docx", null, MIMETYPE_OPENXML_WORDPROCESSING,
-            "jpeg", MIMETYPE_IMAGE_JPEG, null, null, readTestFile("docx"));
+            "jpeg", MIMETYPE_IMAGE_JPEG, null, null, null, readTestFile("docx"));
         assertTrue("Expected image content but content is empty.",
             result.getResponse().getContentLengthLong() > 0L);
     }
@@ -408,6 +482,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
         String targetMimetype,
         String targetEncoding,
         String pageLimit,
+        String extractMapping,
         byte[] content) throws Exception
     {
         final MockMultipartFile sourceFile = new MockMultipartFile("file",
@@ -432,6 +507,10 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
         if (pageLimit != null)
         {
             requestBuilder.param("pageLimit", pageLimit);
+        }
+        if (extractMapping != null)
+        {
+            requestBuilder.param("extractMapping", extractMapping);
         }
 
         return mockMvc.perform(requestBuilder)

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/resources/misc_engine_config.json
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/resources/misc_engine_config.json
@@ -5,6 +5,9 @@
     ],
     "stringOptions": [
       {"value": {"name": "targetEncoding"}}
+    ],
+    "metadataOptions": [
+      {"value": {"name": "extractMapping"}}
     ]
   },
   "transformers": [
@@ -77,6 +80,7 @@
         {"sourceMediaType": "application/xhtml+xml",                         "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -85,6 +89,7 @@
         {"sourceMediaType": "message/rfc822",                                "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     }
   ]

--- a/alfresco-transform-misc/alfresco-transform-misc/src/main/java/org/alfresco/transformer/metadataExtractors/HtmlMetadataExtractor.java
+++ b/alfresco-transform-misc/alfresco-transform-misc/src/main/java/org/alfresco/transformer/metadataExtractors/HtmlMetadataExtractor.java
@@ -78,8 +78,7 @@ public class HtmlMetadataExtractor extends AbstractMetadataExtractor implements 
     public void extractMetadata(String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
                                 File sourceFile, File targetFile) throws Exception
     {
-        Map<String, Serializable> metadata = extractMetadata(sourceMimetype, transformOptions, sourceFile);
-        mapMetadataAndWrite(targetFile, metadata);
+        extractMetadata(sourceMimetype, transformOptions, sourceFile, targetFile);
     }
 
     @Override

--- a/alfresco-transform-misc/alfresco-transform-misc/src/main/java/org/alfresco/transformer/metadataExtractors/RFC822MetadataExtractor.java
+++ b/alfresco-transform-misc/alfresco-transform-misc/src/main/java/org/alfresco/transformer/metadataExtractors/RFC822MetadataExtractor.java
@@ -86,8 +86,7 @@ public class RFC822MetadataExtractor extends AbstractMetadataExtractor implement
     public void extractMetadata(String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
                                 File sourceFile, File targetFile) throws Exception
     {
-        Map<String, Serializable> metadata = extractMetadata(sourceMimetype, transformOptions, sourceFile);
-        mapMetadataAndWrite(targetFile, metadata);
+        extractMetadata(sourceMimetype, transformOptions, sourceFile, targetFile);
     }
 
     @Override

--- a/alfresco-transform-misc/alfresco-transform-misc/src/main/resources/misc_engine_config.json
+++ b/alfresco-transform-misc/alfresco-transform-misc/src/main/resources/misc_engine_config.json
@@ -5,6 +5,9 @@
     ],
     "stringOptions": [
        {"value": {"name": "targetEncoding"}}
+    ],
+    "metadataOptions": [
+      {"value": {"name": "extractMapping"}}
     ]
   },
   "transformers": [
@@ -77,6 +80,7 @@
         {"sourceMediaType": "application/xhtml+xml",                         "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -85,6 +89,7 @@
         {"sourceMediaType": "message/rfc822",                                "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     }
   ]

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/tika_engine_config.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/tika_engine_config.json
@@ -10,6 +10,9 @@
     "pdfboxOptions": [
       {"value": {"name": "notExtractBookmarksText"}},
       {"value": {"name": "targetEncoding"}}
+    ],
+    "metadataOptions": [
+      {"value": {"name": "extractMapping"}}
     ]
   },
   "transformers": [
@@ -520,6 +523,7 @@
         {"sourceMediaType": "image/x-dwg",                                                                "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -528,6 +532,7 @@
         {"sourceMediaType": "application/vnd.ms-outlook",                                                 "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -536,6 +541,7 @@
         {"sourceMediaType": "audio/mpeg",                                                                 "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -556,6 +562,7 @@
         {"sourceMediaType": "application/x-tika-ooxml-protected",                                         "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -601,6 +608,7 @@
         {"sourceMediaType": "application/x-vnd.oasis.opendocument.graphics",                              "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -610,6 +618,7 @@
         {"sourceMediaType": "application/illustrator",                                                    "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -645,6 +654,7 @@
         {"sourceMediaType": "application/vnd.ms-excel.template.macroenabled.12",                          "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -662,6 +672,7 @@
         {"sourceMediaType": "video/mp4",                                                                  "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -968,6 +979,7 @@
         {"sourceMediaType": "image/hfa",                                                                  "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     }
   ]

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/executors/TikaJavaExecutor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/executors/TikaJavaExecutor.java
@@ -168,8 +168,7 @@ public class TikaJavaExecutor implements JavaExecutor
                             throws Exception
     {
         AbstractTikaMetadataExtractor metadataExtractor = this.metadataExtractor.get(transformName);
-        Map<String, Serializable> metadata = metadataExtractor.extractMetadata(sourceMimetype, transformOptions, sourceFile);
-        metadataExtractor.mapMetadataAndWrite(targetFile, metadata);
+        metadataExtractor.extractMetadata(sourceMimetype, transformOptions, sourceFile, targetFile);
     }
 
     /**

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/resources/tika_engine_config.json
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/resources/tika_engine_config.json
@@ -10,6 +10,9 @@
     "pdfboxOptions": [
       {"value": {"name": "notExtractBookmarksText"}},
       {"value": {"name": "targetEncoding"}}
+    ],
+    "metadataOptions": [
+      {"value": {"name": "extractMapping"}}
     ]
   },
   "transformers": [
@@ -520,6 +523,7 @@
         {"sourceMediaType": "image/x-dwg",                                                                "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -528,6 +532,7 @@
         {"sourceMediaType": "application/vnd.ms-outlook",                                                 "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -536,6 +541,7 @@
         {"sourceMediaType": "audio/mpeg",                                                                 "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -556,6 +562,7 @@
         {"sourceMediaType": "application/x-tika-ooxml-protected",                                         "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -601,6 +608,7 @@
         {"sourceMediaType": "application/x-vnd.oasis.opendocument.graphics",                              "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -610,6 +618,7 @@
         {"sourceMediaType": "application/illustrator",                                                    "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -645,6 +654,7 @@
         {"sourceMediaType": "application/vnd.ms-excel.template.macroenabled.12",                          "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -662,6 +672,7 @@
         {"sourceMediaType": "video/mp4",                                                                  "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     },
     {
@@ -968,6 +979,7 @@
         {"sourceMediaType": "image/hfa",                                                                  "targetMediaType": "alfresco-metadata-extract"}
       ],
       "transformOptions": [
+        "metadataOptions"
       ]
     }
   ]

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency.alfresco-transform-model.version>1.0.2.11</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.15.9</dependency.activemq.version>
         <dependency.jackson.version>2.10.3</dependency.jackson.version>
-        <dependency.cxf.version>3.3.5</dependency.cxf.version>
+        <dependency.cxf.version>3.4.1</dependency.cxf.version>
         <dependency.tika.version>1.24.1</dependency.tika.version>
         <dependency.poi.version>4.1.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency.alfresco-jodconverter-core.version>3.0.1.1</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
         <dependency.alfresco-transform-model.version>1.0.2.11</dependency.alfresco-transform-model.version>
-        <dependency.activemq.version>5.15.9</dependency.activemq.version>
+        <dependency.activemq.version>5.15.13</dependency.activemq.version>
         <dependency.jackson.version>2.10.3</dependency.jackson.version>
         <dependency.cxf.version>3.4.1</dependency.cxf.version>
         <dependency.tika.version>1.24.1</dependency.tika.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <version>2.3.5.RELEASE</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Linked to: REPO-5219 Allow AGS AMP to specify metadata extract mapping

Added an extractMapping transform option to all metadata extractors to override the default one.