### PR TITLE
REPO-5191 Bug: T-Engine should provide mapping rather than the repo.

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTikaTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTikaTest.java
@@ -75,12 +75,20 @@ public class AIOControllerTikaTest extends TikaControllerTest
         // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
-    
+
     @Test
     @Override
     public void testGetInfoFromConfigWithNoTransformOptions()
     {
         // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
+    }
+
+    @Test
+    @Override
+    public void xlsxEmbedTest()
+    {
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
+        // It uses the real class path rather than the test one.
     }
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/resources/tika_engine_config.json
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/resources/tika_engine_config.json
@@ -13,6 +13,10 @@
     ],
     "metadataOptions": [
       {"value": {"name": "extractMapping"}}
+    ],
+    "metadataEmbedOptions": [
+      {"value": {"name": "metadata", "required": true}},
+      {"value": {"name": "targetEncoding"}}
     ]
   },
   "transformers": [
@@ -980,6 +984,15 @@
       ],
       "transformOptions": [
         "metadataOptions"
+      ]
+    },
+    {
+      "transformerName": "SamplePoiMetadataEmbedder",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",          "targetMediaType": "alfresco-metadata-embed"}
+      ],
+      "transformOptions": [
+        "metadataEmbedOptions"
       ]
     }
   ]

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/tika_engine_config.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/tika_engine_config.json
@@ -13,6 +13,10 @@
     ],
     "metadataOptions": [
       {"value": {"name": "extractMapping"}}
+    ],
+    "metadataEmbedOptions": [
+      {"value": {"name": "metadata", "required": true}},
+      {"value": {"name": "targetEncoding"}}
     ]
   },
   "transformers": [
@@ -980,6 +984,15 @@
       ],
       "transformOptions": [
         "metadataOptions"
+      ]
+    },
+    {
+      "transformerName": "SamplePoiMetadataEmbedder",
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",          "targetMediaType": "alfresco-metadata-embed"}
+      ],
+      "transformOptions": [
+        "metadataEmbedOptions"
       ]
     }
   ]

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/executors/TikaJavaExecutor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/executors/TikaJavaExecutor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -44,7 +44,6 @@ import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -81,6 +80,7 @@ public class TikaJavaExecutor implements JavaExecutor
             .build();
     private final Map<String, AbstractTikaMetadataExtractor> metadataEmbedder = ImmutableMap
             .<String, AbstractTikaMetadataExtractor>builder()
+            .put("SamplePoiMetadataEmbedder", new PoiMetadataExtractor())
             .build();
 
     public TikaJavaExecutor()
@@ -119,7 +119,7 @@ public class TikaJavaExecutor implements JavaExecutor
     }
 
     @Override
-    public void call(File sourceFile, File targetFile, String... args) throws Exception
+    public void call(File sourceFile, File targetFile, String... args)
     {
         args = buildArgs(sourceFile, targetFile, args);
         tika.transform(args);

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -53,6 +53,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
@@ -316,15 +317,52 @@ public abstract class AbstractTikaMetadataExtractor extends AbstractMetadataExtr
             return;
         }
 
-        Metadata metadataToEmbed = new Metadata();
-        Map<String, String> metadataAsStrings = getMetadata(transformOptions);
-        metadataAsStrings.forEach((k,v)->metadataToEmbed.add(k, v));
+        Metadata metadataToEmbed = getTikaMetadata(transformOptions);
 
         try (InputStream inputStream = new FileInputStream(sourceFile);
              OutputStream outputStream = new FileOutputStream(targetFile))
         {
             embedder.embed(metadataToEmbed, inputStream, outputStream, null);
         }
+    }
+
+    private Metadata getTikaMetadata(Map<String, String> transformOptions) {
+        Metadata metadataToEmbed = new Metadata();
+        Map<String, Serializable> properties = getMetadata(transformOptions);
+        for (String metadataKey : properties.keySet())
+        {
+            Serializable value = properties.get(metadataKey);
+            if (value == null)
+            {
+                continue;
+            }
+            if (value instanceof Collection<?>)
+            {
+                for (Object singleValue : (Collection<?>) value)
+                {
+                    try
+                    {
+                        metadataToEmbed.add(metadataKey, (String)singleValue);
+                    }
+                    catch (ClassCastException e)
+                    {
+                        logger.info("Could not convert " + metadataKey + ": " + e.getMessage());
+                    }
+                }
+            }
+            else
+            {
+                try
+                {
+                    metadataToEmbed.add(metadataKey, (String)value);
+                }
+                catch (ClassCastException e)
+                {
+                    logger.info("Could not convert " + metadataKey + ": " + e.getMessage());
+                }
+            }
+        }
+        return metadataToEmbed;
     }
 
     private Serializable getMetadataValues(Metadata metadata, String key)

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
@@ -326,7 +326,8 @@ public abstract class AbstractTikaMetadataExtractor extends AbstractMetadataExtr
         }
     }
 
-    private Metadata getTikaMetadata(Map<String, String> transformOptions) {
+    private Metadata getTikaMetadata(Map<String, String> transformOptions)
+    {
         Metadata metadataToEmbed = new Metadata();
         Map<String, Serializable> properties = getMetadata(transformOptions);
         for (String metadataKey : properties.keySet())

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/PoiMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/PoiMetadataExtractor.java
@@ -29,7 +29,6 @@ package org.alfresco.transformer.metadataExtractors;
 import org.apache.poi.ooxml.POIXMLProperties;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.tika.embedder.Embedder;
-import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.ParseContext;
@@ -38,8 +37,6 @@ import org.apache.tika.parser.microsoft.ooxml.OOXMLParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/PoiMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/PoiMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,10 +26,26 @@
  */
 package org.alfresco.transformer.metadataExtractors;
 
+import org.apache.poi.ooxml.POIXMLProperties;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.tika.embedder.Embedder;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.microsoft.ooxml.OOXMLParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.Set;
+import java.util.StringJoiner;
 
 /**
  * POI-based metadata extractor for Office 07 documents. See http://poi.apache.org/ for information on POI.
@@ -46,6 +62,34 @@ import org.slf4j.LoggerFactory;
  *
  * Uses Apache Tika
  *
+ * Also includes a sample POI metadata embedder to demonstrate it is possible to add custom T-Engines that will add
+ * metadata. This is not production code so no supported mimetypes exist in the {@code tika_engine_config.json}.
+ * Adding the following would make it available:
+ *
+ * <pre>
+ * {
+ *   "transformOptions": {
+ *     ...
+ *     "metadataEmbedOptions": [
+ *       {"value": {"name": "metadata", "required": true}}
+ *     ]
+ *   },
+ *   "transformers": [
+ *     ...
+ *     {
+ *       "transformerName": "SamplePoiMetadataEmbedder",
+ *       "supportedSourceAndTargetList": [
+ *         ...
+ *         {"sourceMediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "targetMediaType": "alfresco-metadata-embed"}
+ *       ],
+ *       "transformOptions": [
+ *         "metadataEmbedOptions"
+ *       ]
+ *     }
+ *   ]
+ * }
+ * </pre>
+
  * @author Nick Burch
  * @author Neil McErlean
  * @author Dmitry Velichkevich
@@ -64,5 +108,71 @@ public class PoiMetadataExtractor extends AbstractTikaMetadataExtractor
     protected Parser getParser()
     {
         return new OOXMLParser();
+    }
+
+    @Override
+    protected Embedder getEmbedder()
+    {
+        return new SamplePoiEmbedder();
+    }
+
+    private static class SamplePoiEmbedder implements Embedder
+    {
+        private static final Set<MediaType> SUPPORTED_EMBED_TYPES =
+                Collections.singleton(MediaType.application("vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+
+        @Override
+        public Set<MediaType> getSupportedEmbedTypes(ParseContext parseContext)
+        {
+            return SUPPORTED_EMBED_TYPES;
+        }
+
+        @Override
+        public void embed(Metadata metadata, InputStream inputStream, OutputStream outputStream, ParseContext parseContext)
+                throws IOException
+        {
+            XSSFWorkbook workbook = new XSSFWorkbook(inputStream);
+            POIXMLProperties props = workbook.getProperties();
+
+            POIXMLProperties.CoreProperties coreProp = props.getCoreProperties();
+            POIXMLProperties.CustomProperties custProp = props.getCustomProperties();
+
+            for (String name : metadata.names())
+            {
+                metadata.isMultiValued("description");
+                String value = null;
+                if (metadata.isMultiValued(name))
+                {
+                    String[] values = metadata.getValues(name);
+                    StringJoiner sj = new StringJoiner(", ");
+                    for (String s : values)
+                    {
+                        sj.add(s);
+                    }
+                    value = sj.toString();
+                }
+                else
+                {
+                    value = metadata.get(name);
+                }
+                switch (name)
+                {
+                    case "author":
+                        coreProp.setCreator(value);
+                        break;
+                    case "title":
+                        coreProp.setTitle(value);
+                        break;
+                    case "description":
+                        coreProp.setDescription(value);
+                        break;
+                    // There are other core values but this is sample code, so we will assume it is a custom value.
+                    default:
+                        custProp.addProperty(name, value);
+                        break;
+                }
+            }
+            workbook.write(outputStream);
+        }
     }
 }


### PR DESCRIPTION
Bug found while reviewing documents on how to create a custom metadata extractor. The original refactor had left the repo doing the mapping. It should have been passing the fully qualified repo properties to the T-Engine to do the mapping.

Linked to:
* https://github.com/Alfresco/alfresco-community-repo/pull/227
* https://github.com/Alfresco/acs-packaging/pull/1826