### PR TITLE
ACS-930 Security update to spring boot 2.4.1

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
@@ -97,11 +97,6 @@
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerHttpRequestTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerHttpRequestTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,12 +26,9 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class AIOControllerHttpRequestTest extends  AbstractHttpRequestTest
 {

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerImageMagickTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerImageMagickTest.java
@@ -34,12 +34,10 @@ import java.util.Map;
 import org.alfresco.transformer.executors.Transformer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -47,7 +45,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * Test the AIOController ImageMagick transforms without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 public class AIOControllerImageMagickTest extends ImageMagickControllerTest

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerImageMagickTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerImageMagickTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,24 +26,24 @@
  */
 package org.alfresco.transformer;
 
-import org.alfresco.transformer.executors.Transformer;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
+import org.alfresco.transformer.executors.Transformer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 /**
@@ -57,7 +57,7 @@ public class AIOControllerImageMagickTest extends ImageMagickControllerTest
     @Autowired
     AIOTransformRegistry transformRegistry;
 
-    @Before @Override
+    @BeforeEach @Override
     public void before() throws IOException
     {       
         ReflectionTestUtils.setField(commandExecutor, "transformCommand", mockTransformCommand);
@@ -90,7 +90,7 @@ public class AIOControllerImageMagickTest extends ImageMagickControllerTest
     public void testTestValidity()
     {
         // just test that we are actually testing against the AIOController (instead of MiscController)
-        assertTrue("Wrong controller wired for test", controller instanceof AIOController);
+        assertTrue(controller instanceof AIOController, "Wrong controller wired for test");
     }
 
     @Test

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerImageMagickTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerImageMagickTest.java
@@ -43,13 +43,13 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@ExtendWith(SpringExtension.class)
-@WebMvcTest(AIOController.class)
-@Import(AIOCustomConfig.class)
 /**
  * Test the AIOController ImageMagick transforms without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(AIOController.class)
+@Import(AIOCustomConfig.class)
 public class AIOControllerImageMagickTest extends ImageMagickControllerTest
 {
    // All tests contained in ImageMagickControllerTest

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerLibreOfficeTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerLibreOfficeTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,22 +26,22 @@
  */
 package org.alfresco.transformer;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
 import org.alfresco.transformer.executors.LibreOfficeJavaExecutor;
 import org.alfresco.transformer.executors.Transformer;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
-
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 /**
@@ -56,7 +56,7 @@ public class AIOControllerLibreOfficeTest extends LibreOfficeControllerTest
     public void testTestValidity()
     {
         // just test that we are actually testing against the AIOController (instead of MiscController)
-        assertTrue("Wrong controller wired for test", controller instanceof AIOController);
+        assertTrue(controller instanceof AIOController,"Wrong controller wired for test");
     }
 
     @Autowired
@@ -87,7 +87,7 @@ public class AIOControllerLibreOfficeTest extends LibreOfficeControllerTest
     @Override
     public void testGetTransformConfigInfo()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
 
@@ -95,21 +95,21 @@ public class AIOControllerLibreOfficeTest extends LibreOfficeControllerTest
     @Override
     public void testGetInfoFromConfigWithDuplicates()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
     @Test
     @Override
     public void testGetInfoFromConfigWithEmptyTransformOptions()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
     @Test
     @Override
     public void testGetInfoFromConfigWithNoTransformOptions()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerLibreOfficeTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerLibreOfficeTest.java
@@ -33,12 +33,10 @@ import java.util.Map;
 import org.alfresco.transformer.executors.LibreOfficeJavaExecutor;
 import org.alfresco.transformer.executors.Transformer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @WebMvcTest(AIOController.class)

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerLibreOfficeTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerLibreOfficeTest.java
@@ -41,7 +41,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 /**

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerMiscTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerMiscTest.java
@@ -34,7 +34,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 public class AIOControllerMiscTest extends MiscControllerTest 

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerMiscTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerMiscTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,15 +26,15 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static junit.framework.TestCase.assertTrue;
-
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 public class AIOControllerMiscTest extends MiscControllerTest 
@@ -46,14 +46,14 @@ public class AIOControllerMiscTest extends MiscControllerTest
     public void testTestValidity()
     {
         // just test that we are actually testing against the AIOController (instead of MiscController)
-        assertTrue("Wrong controller wired for test", controller instanceof AIOController);
+        assertTrue(controller instanceof AIOController, "Wrong controller wired for test");
     }
     
     @Test
     @Override
     public void testGetTransformConfigInfo()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentality different.
 
     }
 
@@ -61,21 +61,21 @@ public class AIOControllerMiscTest extends MiscControllerTest
     @Override
     public void testGetInfoFromConfigWithDuplicates()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
     @Test
     @Override
     public void testGetInfoFromConfigWithEmptyTransformOptions()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
     @Test
     @Override
     public void testGetInfoFromConfigWithNoTransformOptions()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerMiscTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerMiscTest.java
@@ -29,10 +29,8 @@ package org.alfresco.transformer;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerPdfRendererTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerPdfRendererTest.java
@@ -33,12 +33,10 @@ import java.util.Map;
 
 import org.alfresco.transformer.executors.Transformer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerPdfRendererTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerPdfRendererTest.java
@@ -42,7 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 /**

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerPdfRendererTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerPdfRendererTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,22 +26,23 @@
  */
 package org.alfresco.transformer;
 
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
 import org.alfresco.transformer.executors.Transformer;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
-
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 /**
@@ -78,14 +79,14 @@ public class AIOControllerPdfRendererTest extends AlfrescoPdfRendererControllerT
     public void testTestValidity()
     {
         // just test that we are actually testing against the AIOController (instead of MiscController)
-        assertTrue("Wrong controller wired for test", controller instanceof AIOController);
+        assertTrue(controller instanceof AIOController, "Wrong controller wired for test");
     }
     
     @Test
     @Override
     public void testGetTransformConfigInfo()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
 
     }
@@ -93,7 +94,7 @@ public class AIOControllerPdfRendererTest extends AlfrescoPdfRendererControllerT
     @Override
     public void testGetInfoFromConfigWithDuplicates()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
 
@@ -101,7 +102,7 @@ public class AIOControllerPdfRendererTest extends AlfrescoPdfRendererControllerT
     @Override
     public void testGetInfoFromConfigWithEmptyTransformOptions()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
     
@@ -109,7 +110,7 @@ public class AIOControllerPdfRendererTest extends AlfrescoPdfRendererControllerT
     @Override
     public void testGetInfoFromConfigWithNoTransformOptions()
     {
-        // Ignore the test in super class as the way the AIO transformer provides config is fundementally different.
+        // Ignore the test in super class as the way the AIO transformer provides config is fundamentally different.
 
     }
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTest.java
@@ -30,11 +30,9 @@ import java.io.IOException;
 
 import org.alfresco.transform.client.model.TransformRequest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,19 +26,18 @@
  */
 package org.alfresco.transformer;
 
-
 import java.io.IOException;
 
 import org.alfresco.transform.client.model.TransformRequest;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@WebMvcTest(AIOController.class)
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(ImageMagickController.class)
 @Import(AIOCustomConfig.class)
 public class AIOControllerTest //extends AbstractTransformerControllerTest 
 {

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTest.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(ImageMagickController.class)
+@WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 public class AIOControllerTest //extends AbstractTransformerControllerTest 
 {

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTest.java
@@ -36,7 +36,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 public class AIOControllerTest //extends AbstractTransformerControllerTest 

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTikaTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTikaTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,16 +26,16 @@
  */
 package org.alfresco.transformer;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@WebMvcTest(AIOController.class)
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(ImageMagickController.class)
 @Import(AIOCustomConfig.class)
 /**
  * Test the AIOController Tika transforms without a server.
@@ -49,7 +49,7 @@ public class AIOControllerTikaTest extends TikaControllerTest
     public void testTestValidity()
     {
         // just test that we are actually testing against the AIOController (instead of MiscController)
-        assertTrue("Wrong controller wired for test", controller instanceof AIOController);
+        assertTrue(controller instanceof AIOController,"Wrong controller wired for test");
     }
 
     @Test

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTikaTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTikaTest.java
@@ -29,12 +29,9 @@ package org.alfresco.transformer;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 /**

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTikaTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOControllerTikaTest.java
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(ImageMagickController.class)
+@WebMvcTest(AIOController.class)
 @Import(AIOCustomConfig.class)
 /**
  * Test the AIOController Tika transforms without a server.

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOImageMagickIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOImageMagickIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,16 +26,7 @@
  */
 package org.alfresco.transformer;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-@RunWith(Parameterized.class)
 public class AIOImageMagickIT extends ImageMagickTransformationIT
 {
-    //Tests are in ImageMagickTransformationIT
-    public AIOImageMagickIT(final Pair<TestFileInfo, Pair<String,String>> entry)
-    {
-        super(entry);
-    }
+    // Tests are in ImageMagickTransformationIT
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOLibreOfficeTransformationIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOLibreOfficeTransformationIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,16 +26,7 @@
  */
 package org.alfresco.transformer;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-@RunWith(Parameterized.class)
 public class AIOLibreOfficeTransformationIT extends LibreOfficeTransformationIT
 {
 
-    public AIOLibreOfficeTransformationIT(final Pair<TestFileInfo, TestFileInfo> entry)
-    {
-        super(entry);
-    }
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOLibreOfficeTransformationIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOLibreOfficeTransformationIT.java
@@ -28,5 +28,5 @@ package org.alfresco.transformer;
 
 public class AIOLibreOfficeTransformationIT extends LibreOfficeTransformationIT
 {
-
+    // Tests are in LibreOfficeTransformationIT
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOMiscMetadataExtractsIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOMiscMetadataExtractsIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,19 +26,13 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 /**
  * Metadata integration tests in the Misc T-Engine, but run from the AIO T-Engine.
  *
  * @author adavis
+ * @author dedwards
  */
-@RunWith(Parameterized.class)
 public class AIOMiscMetadataExtractsIT extends MiscMetadataExtractsIT
 {
-    public AIOMiscMetadataExtractsIT(TestFileInfo testFileInfo)
-    {
-        super(testFileInfo);
-    }
+    //Tests are in MiscMetadataExtractsIT
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOMiscTransformsIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOMiscTransformsIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,15 +26,7 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-@RunWith(Parameterized.class)
 public class AIOMiscTransformsIT extends MiscTransformsIT
 {
-    //Tests are in ImageMagickTransformationIT
-    public AIOMiscTransformsIT(final SourceTarget sourceTarget)
-    {
-        super(sourceTarget);
-    }
+    // Tests are in ImageMagickTransformationIT
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOPdfRendererIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOPdfRendererIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,14 +26,6 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-@RunWith(Parameterized.class)
 public class AIOPdfRendererIT extends AlfrescoPdfRendererTransformationIT {
     // Tests are in AlfrescoPdfRendererTransformationIT
-    public AIOPdfRendererIT(String sourceFile)
-    {
-        super(sourceFile);
-    }
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOQueueTransformServiceIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOQueueTransformServiceIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -32,15 +32,12 @@ import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_TEXT_PLAIN;
 import java.util.UUID;
 
 import org.alfresco.transform.client.model.TransformRequest;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author David Edwards
  * created on 21/04/2020
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
                 properties = {"activemq.url=nio://localhost:61616"})
 public class AIOQueueTransformServiceIT extends AbstractQueueTransformServiceIT

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOTikaMetadataExtractsIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOTikaMetadataExtractsIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,19 +26,13 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 /**
  * Metadata integration tests in the Tika T-Engine, but run from the AIO T-Engine.
  *
  * @author adavis
+ * @author dedwards
  */
-@RunWith(Parameterized.class)
 public class AIOTikaMetadataExtractsIT extends TikaMetadataExtractsIT
 {
-    public AIOTikaMetadataExtractsIT(TestFileInfo testFileInfo)
-    {
-        super(testFileInfo);
-    }
+    // Tests are in TikaMetadataExtractsIT
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOTikaTransformationIT.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/test/java/org/alfresco/transformer/AIOTikaTransformationIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,17 +26,7 @@
  */
 package org.alfresco.transformer;
 
-import org.apache.commons.lang3.tuple.Triple;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-@RunWith(Parameterized.class)
 public class AIOTikaTransformationIT extends TikaTransformationIT
 {
-
-    //Tests are in ImageMagickTransformationIT
-    public AIOTikaTransformationIT(final Triple<String, String, String> entry)
-    {
-        super(entry);
-    }
+    // Tests are in ImageMagickTransformationIT
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/pom.xml
@@ -44,9 +44,15 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
@@ -33,8 +33,8 @@ import org.alfresco.transformer.executors.Transformer;
 import org.alfresco.transformer.transformers.SelectingTransformer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.File;
@@ -52,8 +52,9 @@ import java.util.stream.Stream;
 
 import static org.alfresco.transformer.util.RequestParamMap.PAGE_LIMIT;
 import static org.alfresco.transformer.util.RequestParamMap.TRANSFORM_NAME_PARAMETER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AIOTransformRegistryTest
 {
@@ -65,7 +66,7 @@ public class AIOTransformRegistryTest
     ObjectMapper objectMapper = new ObjectMapper();
 
 
-    @Before
+    @BeforeEach
     public void before() throws Exception
     {
         aioTransformerRegistry.registerTransformer(new SelectingTransformer());
@@ -104,32 +105,34 @@ public class AIOTransformRegistryTest
         TransformConfig tikaConfig = loadConfig("tika_engine_config.json");
 
         // check correct number of transformers
-        assertEquals("Number of expected transformers",
+        assertEquals(
                 miscConfig.getTransformers().size() + tikaConfig.getTransformers().size(),
-                aioTransformerRegistry.getTransformConfig().getTransformers().size());
+                aioTransformerRegistry.getTransformConfig().getTransformers().size(),
+                "Number of expected transformers");
 
         List<String> actualTransformerNames = aioTransformerRegistry.getTransformConfig().getTransformers()
                 .stream().map(t -> t.getTransformerName()).collect(Collectors.toList());
         // check all transformers are there
         for(String transformNames : expectedTransformNames)
         {
-            assertTrue("Expected transformer missing.",  actualTransformerNames.contains(transformNames));
+            assertTrue(actualTransformerNames.contains(transformNames),"Expected transformer missing.");
         }
 
         // check correct number of options
         long distinctOptionCount = Stream.concat(
                 miscConfig.getTransformOptions().keySet().stream(),
                 tikaConfig.getTransformOptions().keySet().stream()).distinct().count();
-        assertEquals("Number of expected transformers",
+        assertEquals(
                 distinctOptionCount,
-                aioTransformerRegistry.getTransformConfig().getTransformOptions().size());
+                aioTransformerRegistry.getTransformConfig().getTransformOptions().size(),
+                "Number of expected transformers");
 
         Set<String> actualOptionNames = aioTransformerRegistry.getTransformConfig().getTransformOptions().keySet();
 
         // check all options are there
         for (String optionName : expectedTransformOptionNames)
         {
-            assertTrue("Expected transform option missing:"+optionName,  actualOptionNames.contains(optionName));
+            assertTrue(actualOptionNames.contains(optionName), "Expected transform option missing:"+optionName);
         }
     }
 
@@ -142,21 +145,23 @@ public class AIOTransformRegistryTest
         for (String transform : tikaTransforms)
         {
             String actualId = aioTransformerRegistry.getByTransformName(transform).getTransformerId();
-            assertEquals("Wrong mapping for transform "+transform, "tika", actualId);
+            assertEquals("tika", actualId, "Wrong mapping for transform "+transform);
         }
 
         for (String transform : miscTransforms)
         {
             String actualId = aioTransformerRegistry.getByTransformName(transform).getTransformerId();
-            assertEquals("Wrong mapping for transform "+transform, "misc", actualId);
+            assertEquals("misc", actualId, "Wrong mapping for transform "+transform);
         }
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void testDuplicateTransformsException() throws Exception
     {
-        // The Misc transformers are already registered
-        aioTransformerRegistry.registerTransformer(new SelectingTransformer());
+        assertThrows(Exception.class, () ->{
+            // The Misc transformers are already registered
+            aioTransformerRegistry.registerTransformer(new SelectingTransformer());
+        });
     }
 
     // Test copied from Misc (HtmlParserContentTransformerTest) See ATS-712 aioTransformerRegistry - html
@@ -313,8 +318,8 @@ public class AIOTransformRegistryTest
         String roundTrip = clean(textWriter.toString());
 
         assertEquals(
-                "Incorrect text in PDF when starting from text in " + encoding,
-                checkText, roundTrip
+                checkText, roundTrip, 
+                "Incorrect text in PDF when starting from text in " + encoding
         );
 
         sourceFile.delete();

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
@@ -59,11 +59,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
@@ -26,44 +26,11 @@
  */
 package org.alfresco.transformer;
 
-import org.alfresco.transform.client.model.TransformReply;
-import org.alfresco.transform.client.model.TransformRequest;
-import org.alfresco.transformer.executors.ImageMagickCommandExecutor;
-import org.alfresco.transformer.executors.RuntimeExec;
-import org.alfresco.transformer.model.FileRefEntity;
-import org.alfresco.transformer.model.FileRefResponse;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.stubbing.Answer;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import javax.annotation.PostConstruct;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import static org.alfresco.transformer.executors.RuntimeExec.ExecutionResult;
 import static org.alfresco.transformer.util.MimetypeMap.PREFIX_IMAGE;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
@@ -80,11 +47,47 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.util.StringUtils.getFilenameExtension;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
+
+import org.alfresco.transform.client.model.TransformReply;
+import org.alfresco.transform.client.model.TransformRequest;
+import org.alfresco.transformer.executors.ImageMagickCommandExecutor;
+import org.alfresco.transformer.executors.RuntimeExec;
+import org.alfresco.transformer.executors.RuntimeExec.ExecutionResult;
+import org.alfresco.transformer.model.FileRefEntity;
+import org.alfresco.transformer.model.FileRefResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
 /**
  * Test the ImageMagickController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(ImageMagickController.class)
 public class ImageMagickControllerTest extends AbstractTransformerControllerTest
 {
@@ -125,7 +128,7 @@ public class ImageMagickControllerTest extends AbstractTransformerControllerTest
     @Autowired
     protected AbstractTransformerController controller;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException
     {
         ReflectionTestUtils.setField(commandExecutor, "transformCommand", mockTransformCommand);
@@ -161,7 +164,7 @@ public class ImageMagickControllerTest extends AbstractTransformerControllerTest
         when(mockTransformCommand.execute(any(), anyLong())).thenAnswer(
             (Answer<RuntimeExec.ExecutionResult>) invocation -> {
                 Map<String, String> actualProperties = invocation.getArgument(0);
-                assertEquals("There should be 3 properties", 3, actualProperties.size());
+                assertEquals(3, actualProperties.size(), "There should be 3 properties");
 
                 String actualOptions = actualProperties.get("options");
                 String actualSource = actualProperties.get("source");
@@ -170,26 +173,23 @@ public class ImageMagickControllerTest extends AbstractTransformerControllerTest
 
                 assertNotNull(actualSource);
                 assertNotNull(actualTarget);
-                if (expectedSourceSuffix != null)
-                {
-                    assertTrue(
-                        "The source file \"" + actualSource + "\" should have ended in \"" + expectedSourceSuffix + "\"",
-                        actualSource.endsWith(expectedSourceSuffix));
-                    actualSource = actualSource.substring(0,
-                        actualSource.length() - expectedSourceSuffix.length());
+                if (expectedSourceSuffix != null) {
+                    assertTrue(actualSource.endsWith(expectedSourceSuffix), 
+                        "The source file \"" + actualSource + "\" should have ended in \"" + expectedSourceSuffix + "\"");
+                    actualSource = actualSource.substring(0, actualSource.length() - expectedSourceSuffix.length());
                 }
 
                 assertNotNull(actualOptions);
                 if (expectedOptions != null)
                 {
-                    assertEquals("expectedOptions", expectedOptions, actualOptions);
+                    assertEquals(expectedOptions, actualOptions,"expectedOptions");
                 }
 
                 Long actualTimeout = invocation.getArgument(1);
                 assertNotNull(actualTimeout);
                 if (expectedTimeout != null)
                 {
-                    assertEquals("expectedTimeout", expectedTimeout, actualTimeout);
+                    assertEquals(expectedTimeout, actualTimeout,"expectedTimeout");
                 }
 
                 // Copy a test file into the target file location if it exists
@@ -205,8 +205,8 @@ public class ImageMagickControllerTest extends AbstractTransformerControllerTest
 
                 // Check the supplied source file has not been changed.
                 byte[] actualSourceFileBytes = Files.readAllBytes(new File(actualSource).toPath());
-                assertTrue("Source file is not the same",
-                    Arrays.equals(expectedSourceFileBytes, actualSourceFileBytes));
+                assertTrue(Arrays.equals(expectedSourceFileBytes, actualSourceFileBytes),
+                        "Source file is not the same");
 
                 return mockExecutionResult;
             });
@@ -222,25 +222,23 @@ public class ImageMagickControllerTest extends AbstractTransformerControllerTest
         return controller;
     }
 
-    @Test
-    public void cropGravityGoodTest() throws Exception
+    @ParameterizedTest
+    @ValueSource(strings = {"North", "NorthEast", "East", "SouthEast", "South", "SouthWest", "West", "NorthWest", "Center"})
+    public void cropGravityGoodTest(String value) throws Exception
     {
-        for (String value : new String[]{"North", "NorthEast", "East", "SouthEast", "South", "SouthWest", "West", "NorthWest", "Center"})
-        {
-            expectedOptions = "-auto-orient " + "-gravity " + value + " +repage";
-            mockMvc
-                .perform(MockMvcRequestBuilders
-                    .multipart("/transform")
-                    .file(sourceFile)
-                    .param("targetExtension", targetExtension)
-                    .param("targetMimetype", targetMimetype)
-                    .param("sourceMimetype", sourceMimetype)
-                    .param("cropGravity", value))
-                .andExpect(status().is(OK.value()))
-                .andExpect(content().bytes(expectedTargetFileBytes))
-                .andExpect(header().string("Content-Disposition",
-                    "attachment; filename*= UTF-8''quick." + targetExtension));
-        }
+        expectedOptions = "-auto-orient " + "-gravity " + value + " +repage";
+        mockMvc
+            .perform(MockMvcRequestBuilders
+                .multipart("/transform")
+                .file(sourceFile)
+                .param("targetExtension", targetExtension)
+                .param("targetMimetype", targetMimetype)
+                .param("sourceMimetype", sourceMimetype)
+                .param("cropGravity", value))
+            .andExpect(status().is(OK.value()))
+            .andExpect(content().bytes(expectedTargetFileBytes))
+            .andExpect(header().string("Content-Disposition",
+                "attachment; filename*= UTF-8''quick." + targetExtension));
     }
 
     @Test

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
@@ -85,7 +85,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Test the ImageMagickController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in the application context, 
 // currently only ImageMagickController.class
 @WebMvcTest()
 public class ImageMagickControllerTest extends AbstractTransformerControllerTest

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
@@ -88,7 +88,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Super class includes tests for the AbstractTransformerController.
  */
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(ImageMagickController.class)
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// currently only ImageMagickController.class
+@WebMvcTest()
 public class ImageMagickControllerTest extends AbstractTransformerControllerTest
 {
     private static final String ENGINE_CONFIG_NAME = "imagemagick_engine_config.json";

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
@@ -66,7 +66,6 @@ import org.alfresco.transformer.model.FileRefEntity;
 import org.alfresco.transformer.model.FileRefResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -79,7 +78,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -87,7 +85,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Test the ImageMagickController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@ExtendWith(SpringExtension.class)
 // Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
 // currently only ImageMagickController.class
 @WebMvcTest()

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickHttpRequestTest.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickHttpRequestTest.java
@@ -26,15 +26,12 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Tests ImageMagickController with a server test harness.
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ImageMagickHttpRequestTest extends AbstractHttpRequestTest
 {

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickHttpRequestTest.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickHttpRequestTest.java
@@ -27,12 +27,11 @@
 package org.alfresco.transformer;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 /**
  * Tests ImageMagickController with a server test harness.
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ImageMagickHttpRequestTest extends AbstractHttpRequestTest
 {
     @Override

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickQueueTransformServiceIT.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickQueueTransformServiceIT.java
@@ -32,15 +32,12 @@ import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_IMAGE_PNG;
 import java.util.UUID;
 
 import org.alfresco.transform.client.model.TransformRequest;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Lucian Tuca
  * created on 15/01/2019
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
                 properties = {"activemq.url=nio://localhost:61616"})
 public class ImageMagickQueueTransformServiceIT extends AbstractQueueTransformServiceIT

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickQueueTransformServiceIT.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickQueueTransformServiceIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickTransformationIT.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickTransformationIT.java
@@ -30,210 +30,130 @@ import static java.text.MessageFormat.format;
 import static java.util.Collections.emptyMap;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
 import static org.alfresco.transformer.EngineClient.sendTRequest;
 import static org.alfresco.transformer.TestFileInfo.testFile;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_3FR;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_ARW;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_APPLICATION_EPS;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_BMP;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_CGM;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_CR2;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_DNG;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_APPLICATION_EPS;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_GIF;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_IEF;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_JP2;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_JPEG;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_K25;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_MRW;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_NEF;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_ORF;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_PBM;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_PEF;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_PGM;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_PNG;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_PNM;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_PPJ;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_PPM;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_PSD;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAS;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_3FR;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_ARW;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_CR2;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_DNG;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_K25;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_MRW;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_NEF;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_ORF;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_PEF;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_R3D;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_RAF;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAS;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_RW2;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_RWL;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_TIFF;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_RAW_X3F;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_TIFF;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_XBM;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_XPM;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_IMAGE_XWD;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 
-import com.google.common.collect.ImmutableList;
-
 /**
  * @author Cezar Leahu
  */
-@RunWith(Parameterized.class)
-public class ImageMagickTransformationIT
-{
+public class ImageMagickTransformationIT {
     private static final Logger logger = LoggerFactory.getLogger(ImageMagickTransformationIT.class);
     private static final String ENGINE_URL = "http://localhost:8090";
-    private static final List<Pair<String,String>> targetExtensions = new ImmutableList.Builder<Pair<String,String>>()
-        .add(Pair.of("3fr",MIMETYPE_IMAGE_RAW_3FR))
-        .add(Pair.of("arw",MIMETYPE_IMAGE_RAW_ARW)) 
-        .add(Pair.of("bmp",MIMETYPE_IMAGE_BMP))
-        .add(Pair.of("cgm",MIMETYPE_IMAGE_CGM))
-        .add(Pair.of("cr2",MIMETYPE_IMAGE_RAW_CR2))
-        .add(Pair.of("dng",MIMETYPE_IMAGE_RAW_DNG))
-        .add(Pair.of("eps",MIMETYPE_APPLICATION_EPS))
-        .add(Pair.of("gif",MIMETYPE_IMAGE_GIF))
-        .add(Pair.of("ief",MIMETYPE_IMAGE_IEF))
-        .add(Pair.of("jp2",MIMETYPE_IMAGE_JP2))
-        .add(Pair.of("jpg",MIMETYPE_IMAGE_JPEG))
-        .add(Pair.of("k25",MIMETYPE_IMAGE_RAW_K25))
-        .add(Pair.of("mrw",MIMETYPE_IMAGE_RAW_MRW))
-        .add(Pair.of("nef",MIMETYPE_IMAGE_RAW_NEF))
-        .add(Pair.of("orf",MIMETYPE_IMAGE_RAW_ORF))
-        .add(Pair.of("pbm",MIMETYPE_IMAGE_PBM))
-        .add(Pair.of("pef",MIMETYPE_IMAGE_RAW_PEF))
-        .add(Pair.of("pgm",MIMETYPE_IMAGE_PGM))
-        .add(Pair.of("png",MIMETYPE_IMAGE_PNG))
-        .add(Pair.of("pnm",MIMETYPE_IMAGE_PNM))
-        .add(Pair.of("ppj",MIMETYPE_IMAGE_PPJ))
-        .add(Pair.of("ppm",MIMETYPE_IMAGE_PPM))
-        .add(Pair.of("r3d",MIMETYPE_IMAGE_RAW_R3D))
-        .add(Pair.of("raf",MIMETYPE_IMAGE_RAW_RAF))
-        .add(Pair.of("ras",MIMETYPE_IMAGE_RAS))
-        .add(Pair.of("rw2",MIMETYPE_IMAGE_RAW_RW2))
-        .add(Pair.of("rwl",MIMETYPE_IMAGE_RAW_RWL))
-        .add(Pair.of("tiff",MIMETYPE_IMAGE_TIFF))
-        .add(Pair.of("x3f",MIMETYPE_IMAGE_RAW_X3F))
-        .add(Pair.of("xbm",MIMETYPE_IMAGE_XBM))
-        .add(Pair.of("xpm",MIMETYPE_IMAGE_XPM))
-        .add(Pair.of("xwd",MIMETYPE_IMAGE_XWD))
-        .build();
+    private static final List<Pair<String, String>> targetExtensions = new ImmutableList.Builder<Pair<String, String>>()
+            .add(Pair.of("3fr", MIMETYPE_IMAGE_RAW_3FR)).add(Pair.of("arw", MIMETYPE_IMAGE_RAW_ARW))
+            .add(Pair.of("bmp", MIMETYPE_IMAGE_BMP)).add(Pair.of("cgm", MIMETYPE_IMAGE_CGM))
+            .add(Pair.of("cr2", MIMETYPE_IMAGE_RAW_CR2)).add(Pair.of("dng", MIMETYPE_IMAGE_RAW_DNG))
+            .add(Pair.of("eps", MIMETYPE_APPLICATION_EPS)).add(Pair.of("gif", MIMETYPE_IMAGE_GIF))
+            .add(Pair.of("ief", MIMETYPE_IMAGE_IEF)).add(Pair.of("jp2", MIMETYPE_IMAGE_JP2))
+            .add(Pair.of("jpg", MIMETYPE_IMAGE_JPEG)).add(Pair.of("k25", MIMETYPE_IMAGE_RAW_K25))
+            .add(Pair.of("mrw", MIMETYPE_IMAGE_RAW_MRW)).add(Pair.of("nef", MIMETYPE_IMAGE_RAW_NEF))
+            .add(Pair.of("orf", MIMETYPE_IMAGE_RAW_ORF)).add(Pair.of("pbm", MIMETYPE_IMAGE_PBM))
+            .add(Pair.of("pef", MIMETYPE_IMAGE_RAW_PEF)).add(Pair.of("pgm", MIMETYPE_IMAGE_PGM))
+            .add(Pair.of("png", MIMETYPE_IMAGE_PNG)).add(Pair.of("pnm", MIMETYPE_IMAGE_PNM))
+            .add(Pair.of("ppj", MIMETYPE_IMAGE_PPJ)).add(Pair.of("ppm", MIMETYPE_IMAGE_PPM))
+            .add(Pair.of("r3d", MIMETYPE_IMAGE_RAW_R3D)).add(Pair.of("raf", MIMETYPE_IMAGE_RAW_RAF))
+            .add(Pair.of("ras", MIMETYPE_IMAGE_RAS)).add(Pair.of("rw2", MIMETYPE_IMAGE_RAW_RW2))
+            .add(Pair.of("rwl", MIMETYPE_IMAGE_RAW_RWL)).add(Pair.of("tiff", MIMETYPE_IMAGE_TIFF))
+            .add(Pair.of("x3f", MIMETYPE_IMAGE_RAW_X3F)).add(Pair.of("xbm", MIMETYPE_IMAGE_XBM))
+            .add(Pair.of("xpm", MIMETYPE_IMAGE_XPM)).add(Pair.of("xwd", MIMETYPE_IMAGE_XWD)).build();
 
-    private static final List<Pair<String,String>> targetExtensionsForPSD = new ImmutableList.Builder<Pair<String,String>>()
-            .add(Pair.of("x3f",MIMETYPE_IMAGE_RAW_X3F))
-            .add(Pair.of("tiff",MIMETYPE_IMAGE_TIFF))
-            .add(Pair.of("rwl",MIMETYPE_IMAGE_RAW_RWL))
-            .add(Pair.of("rw2",MIMETYPE_IMAGE_RAW_RW2))
-            .add(Pair.of("ras",MIMETYPE_IMAGE_RAS))
-            .add(Pair.of("raf",MIMETYPE_IMAGE_RAW_RAF))
-            .add(Pair.of("r3d",MIMETYPE_IMAGE_RAW_R3D))
-            .add(Pair.of("psd",MIMETYPE_IMAGE_PSD))
-            .add(Pair.of("ppm",MIMETYPE_IMAGE_PPM))
-            .add(Pair.of("ppj",MIMETYPE_IMAGE_PPJ))
-            .add(Pair.of("pnm",MIMETYPE_IMAGE_PNM))
-            .add(Pair.of("pgm",MIMETYPE_IMAGE_PGM))
-            .add(Pair.of("pef",MIMETYPE_IMAGE_RAW_PEF))
-            .add(Pair.of("pbm",MIMETYPE_IMAGE_PBM))
-            .add(Pair.of("orf",MIMETYPE_IMAGE_RAW_ORF))
-            .add(Pair.of("nef",MIMETYPE_IMAGE_RAW_NEF))
-            .add(Pair.of("mrw",MIMETYPE_IMAGE_RAW_MRW))
-            .add(Pair.of("k25",MIMETYPE_IMAGE_RAW_K25))
-            .add(Pair.of("ief",MIMETYPE_IMAGE_IEF))
-            .add(Pair.of("gif",MIMETYPE_IMAGE_GIF))
-            .add(Pair.of("dng",MIMETYPE_IMAGE_RAW_DNG))
-            .add(Pair.of("cr2",MIMETYPE_IMAGE_RAW_CR2))
-            .add(Pair.of("arw",MIMETYPE_IMAGE_RAW_ARW))
-            .add(Pair.of("3fr",MIMETYPE_IMAGE_RAW_3FR))
-            .build();
+    private static final List<Pair<String, String>> targetExtensionsForPSD = new ImmutableList.Builder<Pair<String, String>>()
+            .add(Pair.of("x3f", MIMETYPE_IMAGE_RAW_X3F)).add(Pair.of("tiff", MIMETYPE_IMAGE_TIFF))
+            .add(Pair.of("rwl", MIMETYPE_IMAGE_RAW_RWL)).add(Pair.of("rw2", MIMETYPE_IMAGE_RAW_RW2))
+            .add(Pair.of("ras", MIMETYPE_IMAGE_RAS)).add(Pair.of("raf", MIMETYPE_IMAGE_RAW_RAF))
+            .add(Pair.of("r3d", MIMETYPE_IMAGE_RAW_R3D)).add(Pair.of("psd", MIMETYPE_IMAGE_PSD))
+            .add(Pair.of("ppm", MIMETYPE_IMAGE_PPM)).add(Pair.of("ppj", MIMETYPE_IMAGE_PPJ))
+            .add(Pair.of("pnm", MIMETYPE_IMAGE_PNM)).add(Pair.of("pgm", MIMETYPE_IMAGE_PGM))
+            .add(Pair.of("pef", MIMETYPE_IMAGE_RAW_PEF)).add(Pair.of("pbm", MIMETYPE_IMAGE_PBM))
+            .add(Pair.of("orf", MIMETYPE_IMAGE_RAW_ORF)).add(Pair.of("nef", MIMETYPE_IMAGE_RAW_NEF))
+            .add(Pair.of("mrw", MIMETYPE_IMAGE_RAW_MRW)).add(Pair.of("k25", MIMETYPE_IMAGE_RAW_K25))
+            .add(Pair.of("ief", MIMETYPE_IMAGE_IEF)).add(Pair.of("gif", MIMETYPE_IMAGE_GIF))
+            .add(Pair.of("dng", MIMETYPE_IMAGE_RAW_DNG)).add(Pair.of("cr2", MIMETYPE_IMAGE_RAW_CR2))
+            .add(Pair.of("arw", MIMETYPE_IMAGE_RAW_ARW)).add(Pair.of("3fr", MIMETYPE_IMAGE_RAW_3FR)).build();
 
-    private static final List<Pair<String,String>> targetExtensionsForTiffFirstPage = new ImmutableList.Builder<Pair<String,String>>()
-            .add(Pair.of("bmp",MIMETYPE_IMAGE_BMP))
-            .add(Pair.of("eps",MIMETYPE_APPLICATION_EPS))
-            .add(Pair.of("jp2",MIMETYPE_IMAGE_JP2))
-            .add(Pair.of("jpg",MIMETYPE_IMAGE_JPEG))
-            .add(Pair.of("png",MIMETYPE_IMAGE_PNG))
-            .add(Pair.of("xbm",MIMETYPE_IMAGE_XBM))
-            .add(Pair.of("xpm",MIMETYPE_IMAGE_XPM))
-            .add(Pair.of("xwd",MIMETYPE_IMAGE_XWD))
-            .build();
+    private static final List<Pair<String, String>> targetExtensionsForTiffFirstPage = new ImmutableList.Builder<Pair<String, String>>()
+            .add(Pair.of("bmp", MIMETYPE_IMAGE_BMP)).add(Pair.of("eps", MIMETYPE_APPLICATION_EPS))
+            .add(Pair.of("jp2", MIMETYPE_IMAGE_JP2)).add(Pair.of("jpg", MIMETYPE_IMAGE_JPEG))
+            .add(Pair.of("png", MIMETYPE_IMAGE_PNG)).add(Pair.of("xbm", MIMETYPE_IMAGE_XBM))
+            .add(Pair.of("xpm", MIMETYPE_IMAGE_XPM)).add(Pair.of("xwd", MIMETYPE_IMAGE_XWD)).build();
 
     private static final Map<String, TestFileInfo> TEST_FILES = Stream.of(
-        testFile(MIMETYPE_IMAGE_BMP,"bmp","quick.bmp"),
-        testFile(MIMETYPE_APPLICATION_EPS,"eps","quick.eps"),
-        testFile(MIMETYPE_IMAGE_GIF,"gif","quick.gif"),
-        testFile(MIMETYPE_IMAGE_JPEG,"jpg","quick.jpg"),
-        testFile(MIMETYPE_IMAGE_PBM,"pbm","quick.pbm"),
-        testFile(MIMETYPE_IMAGE_PGM,"pgm","quick.pgm"),
-        testFile(MIMETYPE_IMAGE_PNG,"png","quick.png"),
-        testFile(MIMETYPE_IMAGE_PNM,"pnm","quick.pnm"),
-        testFile(MIMETYPE_IMAGE_PPM,"ppm","quick.ppm"),
-        testFile(MIMETYPE_IMAGE_XBM,"xbm","quick.xbm"),
-        testFile(MIMETYPE_IMAGE_XPM,"xpm","quick.xpm"),
-        testFile(MIMETYPE_IMAGE_PSD,"psd","quick.psd"),
-        testFile(MIMETYPE_IMAGE_TIFF,"tiff","quick.tiff"),
-        testFile(MIMETYPE_IMAGE_XWD,"xwd","quick.xwd")
-    ).collect(toMap(TestFileInfo::getPath, identity()));
+            testFile(MIMETYPE_IMAGE_BMP, "bmp", "quick.bmp"), testFile(MIMETYPE_APPLICATION_EPS, "eps", "quick.eps"),
+            testFile(MIMETYPE_IMAGE_GIF, "gif", "quick.gif"), testFile(MIMETYPE_IMAGE_JPEG, "jpg", "quick.jpg"),
+            testFile(MIMETYPE_IMAGE_PBM, "pbm", "quick.pbm"), testFile(MIMETYPE_IMAGE_PGM, "pgm", "quick.pgm"),
+            testFile(MIMETYPE_IMAGE_PNG, "png", "quick.png"), testFile(MIMETYPE_IMAGE_PNM, "pnm", "quick.pnm"),
+            testFile(MIMETYPE_IMAGE_PPM, "ppm", "quick.ppm"), testFile(MIMETYPE_IMAGE_XBM, "xbm", "quick.xbm"),
+            testFile(MIMETYPE_IMAGE_XPM, "xpm", "quick.xpm"), testFile(MIMETYPE_IMAGE_PSD, "psd", "quick.psd"),
+            testFile(MIMETYPE_IMAGE_TIFF, "tiff", "quick.tiff"), testFile(MIMETYPE_IMAGE_XWD, "xwd", "quick.xwd"))
+            .collect(toMap(TestFileInfo::getPath, identity()));
 
-    private final String sourceFile;
-    private final String targetExtension;
-    private final String sourceMimetype;
-    private final String targetMimetype;
-
-    public ImageMagickTransformationIT(final Pair<TestFileInfo, Pair<String,String>> entry)
+    @ParameterizedTest
+    @MethodSource("engineTransformations")
+    public void testTransformation(Pair<TestFileInfo, Pair<String, String>> entry)
     {
-        sourceFile = entry.getLeft().getPath();
-        targetExtension = entry.getRight().getLeft();
-        sourceMimetype = entry.getLeft().getMimeType();
-        targetMimetype = entry.getRight().getRight();
-    }
-
-    @Parameterized.Parameters
-    public static Set<Pair<TestFileInfo, Pair<String,String>>> engineTransformations()
-    {
-        Set<Pair<TestFileInfo, Pair<String,String>>> resolved = null;
-        resolved = Stream
-            .of(
-                allTargets("quick.bmp", targetExtensions),
-                allTargets("quick.eps", targetExtensions),
-                allTargets("quick.gif", targetExtensions),
-                allTargets("quick.jpg", targetExtensions),
-                allTargets("quick.pbm", targetExtensions),
-                allTargets("quick.pgm", targetExtensions),
-                allTargets("quick.png", targetExtensions),
-                allTargets("quick.pnm", targetExtensions),
-                allTargets("quick.ppm", targetExtensions),
-                allTargets("quick.psd", targetExtensionsForPSD),
-                allTargets("quick.tiff", targetExtensions),
-                allTargets("quick.xbm", targetExtensions),
-                allTargets("quick.xpm", targetExtensions),
-                allTargets("quick.xwd", targetExtensions)
-            )
-            .flatMap(identity())
-            .collect(toSet());
-        return resolved;
-    }
-
-    @Test
-    public void testTransformation()
-    {
+        String sourceFile = entry.getLeft().getPath();
+        String targetExtension = entry.getRight().getLeft();
+        String sourceMimetype = entry.getLeft().getMimeType();
+        String targetMimetype = entry.getRight().getRight();
+        
         final String descriptor = format("Transform ({0}, {1} -> {2}, {3})",
             sourceFile, sourceMimetype, targetMimetype, targetExtension);
         try
         {
             // note: some image/tiff->image/* will return multiple page results (hence error) unless options specified for single page
             Map<String, String> tOptions = emptyMap();
-            Pair targetPair = Pair.of(targetExtension, targetMimetype);
+            Pair<String,String> targetPair = Pair.of(targetExtension, targetMimetype);
             if (MIMETYPE_IMAGE_TIFF.equals(sourceMimetype) && targetExtensionsForTiffFirstPage.contains(targetPair))
             {
                 tOptions = ImmutableMap.of("startPage", "0", "endPage", "0");
@@ -241,7 +161,7 @@ public class ImageMagickTransformationIT
 
             final ResponseEntity<Resource> response = sendTRequest(ENGINE_URL, sourceFile, sourceMimetype,
                 targetMimetype, targetExtension, tOptions);
-            assertEquals(descriptor, OK, response.getStatusCode());
+            assertEquals(OK, response.getStatusCode(), descriptor);
         }
         catch (Exception e)
         {
@@ -256,4 +176,15 @@ public class ImageMagickTransformationIT
             .map(k -> Pair.of(TEST_FILES.get(sourceFile), k));
     }
 
+    public static Stream<Pair<TestFileInfo, Pair<String,String>>> engineTransformations() {
+        return Stream.of(
+                allTargets("quick.bmp", targetExtensions), allTargets("quick.eps", targetExtensions),
+                allTargets("quick.gif", targetExtensions), allTargets("quick.jpg", targetExtensions),
+                allTargets("quick.pbm", targetExtensions), allTargets("quick.pgm", targetExtensions),
+                allTargets("quick.png", targetExtensions), allTargets("quick.pnm", targetExtensions),
+                allTargets("quick.ppm", targetExtensions), allTargets("quick.psd", targetExtensionsForPSD),
+                allTargets("quick.tiff", targetExtensions), allTargets("quick.xbm", targetExtensions),
+                allTargets("quick.xpm", targetExtensions), allTargets("quick.xwd", targetExtensions)
+               ).flatMap(i -> i);
+    }
 }

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickTransformationIT.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickTransformationIT.java
@@ -91,52 +91,114 @@ public class ImageMagickTransformationIT {
     private static final Logger logger = LoggerFactory.getLogger(ImageMagickTransformationIT.class);
     private static final String ENGINE_URL = "http://localhost:8090";
     private static final List<Pair<String, String>> targetExtensions = new ImmutableList.Builder<Pair<String, String>>()
-            .add(Pair.of("3fr", MIMETYPE_IMAGE_RAW_3FR)).add(Pair.of("arw", MIMETYPE_IMAGE_RAW_ARW))
-            .add(Pair.of("bmp", MIMETYPE_IMAGE_BMP)).add(Pair.of("cgm", MIMETYPE_IMAGE_CGM))
-            .add(Pair.of("cr2", MIMETYPE_IMAGE_RAW_CR2)).add(Pair.of("dng", MIMETYPE_IMAGE_RAW_DNG))
-            .add(Pair.of("eps", MIMETYPE_APPLICATION_EPS)).add(Pair.of("gif", MIMETYPE_IMAGE_GIF))
-            .add(Pair.of("ief", MIMETYPE_IMAGE_IEF)).add(Pair.of("jp2", MIMETYPE_IMAGE_JP2))
-            .add(Pair.of("jpg", MIMETYPE_IMAGE_JPEG)).add(Pair.of("k25", MIMETYPE_IMAGE_RAW_K25))
-            .add(Pair.of("mrw", MIMETYPE_IMAGE_RAW_MRW)).add(Pair.of("nef", MIMETYPE_IMAGE_RAW_NEF))
-            .add(Pair.of("orf", MIMETYPE_IMAGE_RAW_ORF)).add(Pair.of("pbm", MIMETYPE_IMAGE_PBM))
-            .add(Pair.of("pef", MIMETYPE_IMAGE_RAW_PEF)).add(Pair.of("pgm", MIMETYPE_IMAGE_PGM))
-            .add(Pair.of("png", MIMETYPE_IMAGE_PNG)).add(Pair.of("pnm", MIMETYPE_IMAGE_PNM))
-            .add(Pair.of("ppj", MIMETYPE_IMAGE_PPJ)).add(Pair.of("ppm", MIMETYPE_IMAGE_PPM))
-            .add(Pair.of("r3d", MIMETYPE_IMAGE_RAW_R3D)).add(Pair.of("raf", MIMETYPE_IMAGE_RAW_RAF))
-            .add(Pair.of("ras", MIMETYPE_IMAGE_RAS)).add(Pair.of("rw2", MIMETYPE_IMAGE_RAW_RW2))
-            .add(Pair.of("rwl", MIMETYPE_IMAGE_RAW_RWL)).add(Pair.of("tiff", MIMETYPE_IMAGE_TIFF))
-            .add(Pair.of("x3f", MIMETYPE_IMAGE_RAW_X3F)).add(Pair.of("xbm", MIMETYPE_IMAGE_XBM))
-            .add(Pair.of("xpm", MIMETYPE_IMAGE_XPM)).add(Pair.of("xwd", MIMETYPE_IMAGE_XWD)).build();
+            .add(Pair.of("3fr", MIMETYPE_IMAGE_RAW_3FR))
+            .add(Pair.of("arw", MIMETYPE_IMAGE_RAW_ARW))
+            .add(Pair.of("bmp", MIMETYPE_IMAGE_BMP))
+            .add(Pair.of("cgm", MIMETYPE_IMAGE_CGM))
+            .add(Pair.of("cr2", MIMETYPE_IMAGE_RAW_CR2))
+            .add(Pair.of("dng", MIMETYPE_IMAGE_RAW_DNG))
+            .add(Pair.of("eps", MIMETYPE_APPLICATION_EPS))
+            .add(Pair.of("gif", MIMETYPE_IMAGE_GIF))
+            .add(Pair.of("ief", MIMETYPE_IMAGE_IEF))
+            .add(Pair.of("jp2", MIMETYPE_IMAGE_JP2))
+            .add(Pair.of("jpg", MIMETYPE_IMAGE_JPEG))
+            .add(Pair.of("k25", MIMETYPE_IMAGE_RAW_K25))
+            .add(Pair.of("mrw", MIMETYPE_IMAGE_RAW_MRW))
+            .add(Pair.of("nef", MIMETYPE_IMAGE_RAW_NEF))
+            .add(Pair.of("orf", MIMETYPE_IMAGE_RAW_ORF))
+            .add(Pair.of("pbm", MIMETYPE_IMAGE_PBM))
+            .add(Pair.of("pef", MIMETYPE_IMAGE_RAW_PEF))
+            .add(Pair.of("pgm", MIMETYPE_IMAGE_PGM))
+            .add(Pair.of("png", MIMETYPE_IMAGE_PNG))
+            .add(Pair.of("pnm", MIMETYPE_IMAGE_PNM))
+            .add(Pair.of("ppj", MIMETYPE_IMAGE_PPJ))
+            .add(Pair.of("ppm", MIMETYPE_IMAGE_PPM))
+            .add(Pair.of("r3d", MIMETYPE_IMAGE_RAW_R3D))
+            .add(Pair.of("raf", MIMETYPE_IMAGE_RAW_RAF))
+            .add(Pair.of("ras", MIMETYPE_IMAGE_RAS))
+            .add(Pair.of("rw2", MIMETYPE_IMAGE_RAW_RW2))
+            .add(Pair.of("rwl", MIMETYPE_IMAGE_RAW_RWL))
+            .add(Pair.of("tiff", MIMETYPE_IMAGE_TIFF))
+            .add(Pair.of("x3f", MIMETYPE_IMAGE_RAW_X3F))
+            .add(Pair.of("xbm", MIMETYPE_IMAGE_XBM))
+            .add(Pair.of("xpm", MIMETYPE_IMAGE_XPM))
+            .add(Pair.of("xwd", MIMETYPE_IMAGE_XWD))
+            .build();
 
     private static final List<Pair<String, String>> targetExtensionsForPSD = new ImmutableList.Builder<Pair<String, String>>()
-            .add(Pair.of("x3f", MIMETYPE_IMAGE_RAW_X3F)).add(Pair.of("tiff", MIMETYPE_IMAGE_TIFF))
-            .add(Pair.of("rwl", MIMETYPE_IMAGE_RAW_RWL)).add(Pair.of("rw2", MIMETYPE_IMAGE_RAW_RW2))
-            .add(Pair.of("ras", MIMETYPE_IMAGE_RAS)).add(Pair.of("raf", MIMETYPE_IMAGE_RAW_RAF))
-            .add(Pair.of("r3d", MIMETYPE_IMAGE_RAW_R3D)).add(Pair.of("psd", MIMETYPE_IMAGE_PSD))
-            .add(Pair.of("ppm", MIMETYPE_IMAGE_PPM)).add(Pair.of("ppj", MIMETYPE_IMAGE_PPJ))
-            .add(Pair.of("pnm", MIMETYPE_IMAGE_PNM)).add(Pair.of("pgm", MIMETYPE_IMAGE_PGM))
-            .add(Pair.of("pef", MIMETYPE_IMAGE_RAW_PEF)).add(Pair.of("pbm", MIMETYPE_IMAGE_PBM))
-            .add(Pair.of("orf", MIMETYPE_IMAGE_RAW_ORF)).add(Pair.of("nef", MIMETYPE_IMAGE_RAW_NEF))
-            .add(Pair.of("mrw", MIMETYPE_IMAGE_RAW_MRW)).add(Pair.of("k25", MIMETYPE_IMAGE_RAW_K25))
-            .add(Pair.of("ief", MIMETYPE_IMAGE_IEF)).add(Pair.of("gif", MIMETYPE_IMAGE_GIF))
-            .add(Pair.of("dng", MIMETYPE_IMAGE_RAW_DNG)).add(Pair.of("cr2", MIMETYPE_IMAGE_RAW_CR2))
-            .add(Pair.of("arw", MIMETYPE_IMAGE_RAW_ARW)).add(Pair.of("3fr", MIMETYPE_IMAGE_RAW_3FR)).build();
+            .add(Pair.of("x3f", MIMETYPE_IMAGE_RAW_X3F))
+            .add(Pair.of("tiff", MIMETYPE_IMAGE_TIFF))
+            .add(Pair.of("rwl", MIMETYPE_IMAGE_RAW_RWL))
+            .add(Pair.of("rw2", MIMETYPE_IMAGE_RAW_RW2))
+            .add(Pair.of("ras", MIMETYPE_IMAGE_RAS))
+            .add(Pair.of("raf", MIMETYPE_IMAGE_RAW_RAF))
+            .add(Pair.of("r3d", MIMETYPE_IMAGE_RAW_R3D))
+            .add(Pair.of("psd", MIMETYPE_IMAGE_PSD))
+            .add(Pair.of("ppm", MIMETYPE_IMAGE_PPM))
+            .add(Pair.of("ppj", MIMETYPE_IMAGE_PPJ))
+            .add(Pair.of("pnm", MIMETYPE_IMAGE_PNM))
+            .add(Pair.of("pgm", MIMETYPE_IMAGE_PGM))
+            .add(Pair.of("pef", MIMETYPE_IMAGE_RAW_PEF))
+            .add(Pair.of("pbm", MIMETYPE_IMAGE_PBM))
+            .add(Pair.of("orf", MIMETYPE_IMAGE_RAW_ORF))
+            .add(Pair.of("nef", MIMETYPE_IMAGE_RAW_NEF))
+            .add(Pair.of("mrw", MIMETYPE_IMAGE_RAW_MRW))
+            .add(Pair.of("k25", MIMETYPE_IMAGE_RAW_K25))
+            .add(Pair.of("ief", MIMETYPE_IMAGE_IEF))
+            .add(Pair.of("gif", MIMETYPE_IMAGE_GIF))
+            .add(Pair.of("dng", MIMETYPE_IMAGE_RAW_DNG))
+            .add(Pair.of("cr2", MIMETYPE_IMAGE_RAW_CR2))
+            .add(Pair.of("arw", MIMETYPE_IMAGE_RAW_ARW))
+            .add(Pair.of("3fr", MIMETYPE_IMAGE_RAW_3FR))
+            .build();
 
     private static final List<Pair<String, String>> targetExtensionsForTiffFirstPage = new ImmutableList.Builder<Pair<String, String>>()
-            .add(Pair.of("bmp", MIMETYPE_IMAGE_BMP)).add(Pair.of("eps", MIMETYPE_APPLICATION_EPS))
-            .add(Pair.of("jp2", MIMETYPE_IMAGE_JP2)).add(Pair.of("jpg", MIMETYPE_IMAGE_JPEG))
-            .add(Pair.of("png", MIMETYPE_IMAGE_PNG)).add(Pair.of("xbm", MIMETYPE_IMAGE_XBM))
-            .add(Pair.of("xpm", MIMETYPE_IMAGE_XPM)).add(Pair.of("xwd", MIMETYPE_IMAGE_XWD)).build();
+            .add(Pair.of("bmp", MIMETYPE_IMAGE_BMP))
+            .add(Pair.of("eps", MIMETYPE_APPLICATION_EPS))
+            .add(Pair.of("jp2", MIMETYPE_IMAGE_JP2))
+            .add(Pair.of("jpg", MIMETYPE_IMAGE_JPEG))
+            .add(Pair.of("png", MIMETYPE_IMAGE_PNG))
+            .add(Pair.of("xbm", MIMETYPE_IMAGE_XBM))
+            .add(Pair.of("xpm", MIMETYPE_IMAGE_XPM))
+            .add(Pair.of("xwd", MIMETYPE_IMAGE_XWD))
+            .build();
 
     private static final Map<String, TestFileInfo> TEST_FILES = Stream.of(
-            testFile(MIMETYPE_IMAGE_BMP, "bmp", "quick.bmp"), testFile(MIMETYPE_APPLICATION_EPS, "eps", "quick.eps"),
-            testFile(MIMETYPE_IMAGE_GIF, "gif", "quick.gif"), testFile(MIMETYPE_IMAGE_JPEG, "jpg", "quick.jpg"),
-            testFile(MIMETYPE_IMAGE_PBM, "pbm", "quick.pbm"), testFile(MIMETYPE_IMAGE_PGM, "pgm", "quick.pgm"),
-            testFile(MIMETYPE_IMAGE_PNG, "png", "quick.png"), testFile(MIMETYPE_IMAGE_PNM, "pnm", "quick.pnm"),
-            testFile(MIMETYPE_IMAGE_PPM, "ppm", "quick.ppm"), testFile(MIMETYPE_IMAGE_XBM, "xbm", "quick.xbm"),
-            testFile(MIMETYPE_IMAGE_XPM, "xpm", "quick.xpm"), testFile(MIMETYPE_IMAGE_PSD, "psd", "quick.psd"),
-            testFile(MIMETYPE_IMAGE_TIFF, "tiff", "quick.tiff"), testFile(MIMETYPE_IMAGE_XWD, "xwd", "quick.xwd"))
-            .collect(toMap(TestFileInfo::getPath, identity()));
+            testFile(MIMETYPE_IMAGE_BMP, "bmp", "quick.bmp"), 
+            testFile(MIMETYPE_APPLICATION_EPS, "eps", "quick.eps"),
+            testFile(MIMETYPE_IMAGE_GIF, "gif", "quick.gif"), 
+            testFile(MIMETYPE_IMAGE_JPEG, "jpg", "quick.jpg"),
+            testFile(MIMETYPE_IMAGE_PBM, "pbm", "quick.pbm"), 
+            testFile(MIMETYPE_IMAGE_PGM, "pgm", "quick.pgm"),
+            testFile(MIMETYPE_IMAGE_PNG, "png", "quick.png"), 
+            testFile(MIMETYPE_IMAGE_PNM, "pnm", "quick.pnm"),
+            testFile(MIMETYPE_IMAGE_PPM, "ppm", "quick.ppm"), 
+            testFile(MIMETYPE_IMAGE_XBM, "xbm", "quick.xbm"),
+            testFile(MIMETYPE_IMAGE_XPM, "xpm", "quick.xpm"), 
+            testFile(MIMETYPE_IMAGE_PSD, "psd", "quick.psd"),
+            testFile(MIMETYPE_IMAGE_TIFF, "tiff", "quick.tiff"), 
+            testFile(MIMETYPE_IMAGE_XWD, "xwd", "quick.xwd")
+        ).collect(toMap(TestFileInfo::getPath, identity()));
+
+    public static Stream<Pair<TestFileInfo, Pair<String,String>>> engineTransformations() {
+        return Stream
+            .of(
+                allTargets("quick.bmp", targetExtensions), 
+                allTargets("quick.eps", targetExtensions),
+                allTargets("quick.gif", targetExtensions), 
+                allTargets("quick.jpg", targetExtensions),
+                allTargets("quick.pbm", targetExtensions), 
+                allTargets("quick.pgm", targetExtensions),
+                allTargets("quick.png", targetExtensions), 
+                allTargets("quick.pnm", targetExtensions),
+                allTargets("quick.ppm", targetExtensions), 
+                allTargets("quick.psd", targetExtensionsForPSD),
+                allTargets("quick.tiff", targetExtensions), 
+                allTargets("quick.xbm", targetExtensions),
+                allTargets("quick.xpm", targetExtensions), 
+                allTargets("quick.xwd", targetExtensions)
+            ).flatMap(identity());
+    }
 
     @ParameterizedTest
     @MethodSource("engineTransformations")
@@ -176,15 +238,5 @@ public class ImageMagickTransformationIT {
             .map(k -> Pair.of(TEST_FILES.get(sourceFile), k));
     }
 
-    public static Stream<Pair<TestFileInfo, Pair<String,String>>> engineTransformations() {
-        return Stream.of(
-                allTargets("quick.bmp", targetExtensions), allTargets("quick.eps", targetExtensions),
-                allTargets("quick.gif", targetExtensions), allTargets("quick.jpg", targetExtensions),
-                allTargets("quick.pbm", targetExtensions), allTargets("quick.pgm", targetExtensions),
-                allTargets("quick.png", targetExtensions), allTargets("quick.pnm", targetExtensions),
-                allTargets("quick.ppm", targetExtensions), allTargets("quick.psd", targetExtensionsForPSD),
-                allTargets("quick.tiff", targetExtensions), allTargets("quick.xbm", targetExtensions),
-                allTargets("quick.xpm", targetExtensions), allTargets("quick.xwd", targetExtensions)
-               ).flatMap(i -> i);
-    }
+    
 }

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
@@ -67,11 +67,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
@@ -26,11 +26,10 @@
  */
 package org.alfresco.transformer;
 
+import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_PDF;
 import static org.alfresco.transformer.util.RequestParamMap.SOURCE_MIMETYPE;
 import static org.alfresco.transformer.util.RequestParamMap.TARGET_EXTENSION;
 import static org.alfresco.transformer.util.RequestParamMap.TARGET_MIMETYPE;
-import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_PDF;
-import static org.alfresco.transformer.executors.RuntimeExec.ExecutionResult;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -55,15 +54,17 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.UUID;
 
+import javax.annotation.PostConstruct;
+
 import org.alfresco.transform.client.model.TransformReply;
 import org.alfresco.transform.client.model.TransformRequest;
 import org.alfresco.transformer.executors.LibreOfficeJavaExecutor;
+import org.alfresco.transformer.executors.RuntimeExec.ExecutionResult;
 import org.alfresco.transformer.model.FileRefEntity;
 import org.alfresco.transformer.model.FileRefResponse;
 import org.artofsolving.jodconverter.office.OfficeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,17 +75,13 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import javax.annotation.PostConstruct;
 
 /**
  * Test the LibreOfficeController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@ExtendWith(SpringExtension.class)
 // Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
 // currently only LibreOfficeController.class
 @WebMvcTest()

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
@@ -85,7 +85,9 @@ import javax.annotation.PostConstruct;
  * Super class includes tests for the AbstractTransformerController.
  */
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(LibreOfficeController.class)
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// currently only LibreOfficeController.class
+@WebMvcTest()
 public class LibreOfficeControllerTest extends AbstractTransformerControllerTest
 {
 

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -32,9 +32,9 @@ import static org.alfresco.transformer.util.RequestParamMap.TARGET_MIMETYPE;
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_PDF;
 import static org.alfresco.transformer.executors.RuntimeExec.ExecutionResult;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -61,9 +61,9 @@ import org.alfresco.transformer.executors.LibreOfficeJavaExecutor;
 import org.alfresco.transformer.model.FileRefEntity;
 import org.alfresco.transformer.model.FileRefResponse;
 import org.artofsolving.jodconverter.office.OfficeException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,7 +74,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -84,7 +84,7 @@ import javax.annotation.PostConstruct;
  * Test the LibreOfficeController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(LibreOfficeController.class)
 public class LibreOfficeControllerTest extends AbstractTransformerControllerTest
 {
@@ -124,7 +124,7 @@ public class LibreOfficeControllerTest extends AbstractTransformerControllerTest
     @Autowired
     protected AbstractTransformerController controller;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException
     {
         sourceExtension = "doc";
@@ -164,8 +164,7 @@ public class LibreOfficeControllerTest extends AbstractTransformerControllerTest
 
             // Check the supplied source file has not been changed.
             byte[] actualSourceFileBytes = Files.readAllBytes(sourceFile.toPath());
-            assertTrue("Source file is not the same",
-                Arrays.equals(expectedSourceFileBytes, actualSourceFileBytes));
+            assertTrue(Arrays.equals(expectedSourceFileBytes, actualSourceFileBytes), "Source file is not the same");
 
             return null;
         }).when(javaExecutor).convert(any(), any());

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
@@ -82,7 +82,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Test the LibreOfficeController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in the application context,
 // currently only LibreOfficeController.class
 @WebMvcTest()
 public class LibreOfficeControllerTest extends AbstractTransformerControllerTest

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeHttpRequestTest.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeHttpRequestTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,14 +26,11 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Tests LibreOfficeController with a server test harness.
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class LibreOfficeHttpRequestTest extends AbstractHttpRequestTest
 {

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeQueueTransformServiceIT.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeQueueTransformServiceIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -31,15 +31,12 @@ import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_OPENXML_WORD
 import java.util.UUID;
 
 import org.alfresco.transform.client.model.TransformRequest;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Lucian Tuca
  * created on 15/01/2019
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
                 properties = {"activemq.url=nio://localhost:61616"})
 public class LibreOfficeQueueTransformServiceIT extends AbstractQueueTransformServiceIT

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeTransformationIT.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeTransformationIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -29,7 +29,6 @@ package org.alfresco.transformer;
 import static java.text.MessageFormat.format;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
 import static org.alfresco.transformer.EngineClient.sendTRequest;
 import static org.alfresco.transformer.TestFileInfo.testFile;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_EXCEL;
@@ -75,6 +74,7 @@ import com.google.common.collect.ImmutableSet;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
@@ -200,6 +200,7 @@ public class LibreOfficeTransformationIT
     }
 
     @ParameterizedTest
+    @MethodSource("engineTransformations")
     public void testTransformation(final Pair<TestFileInfo, TestFileInfo> entry)
     {
         final String sourceFile = entry.getLeft().getPath();
@@ -212,7 +213,7 @@ public class LibreOfficeTransformationIT
         {
             final ResponseEntity<Resource> response = sendTRequest(ENGINE_URL, sourceFile, sourceMimetype,
                 targetMimetype, targetExtension);
-            assertEquals(descriptor, OK, response.getStatusCode());
+            assertEquals(OK, response.getStatusCode(), descriptor);
         }
         catch (Exception e)
         {

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeTransformationIT.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeTransformationIT.java
@@ -63,8 +63,8 @@ import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_SXC;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_STW;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_STI;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_STC;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.Map;
@@ -74,9 +74,7 @@ import java.util.stream.Stream;
 import com.google.common.collect.ImmutableSet;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
@@ -85,7 +83,6 @@ import org.springframework.http.ResponseEntity;
 /**
  * @author Cezar Leahu
  */
-@RunWith(Parameterized.class)
 public class LibreOfficeTransformationIT
 {
     private static final Logger logger = LoggerFactory.getLogger(LibreOfficeTransformationIT.class);
@@ -127,11 +124,6 @@ public class LibreOfficeTransformationIT
             testFile(MIMETYPE_TEXT_PLAIN,"txt",null)
     );
 
-    private final String sourceFile;
-    private final String targetExtension;
-    private final String sourceMimetype;
-    private final String targetMimetype;
-
     private static final Map<String,TestFileInfo> TEST_FILES = Stream.of(
         testFile(MIMETYPE_WORD                                 ,"doc"  ,"quick.doc"),
         testFile(MIMETYPE_OPENXML_WORDPROCESSING               ,"docx" ,"quick.docx"),
@@ -164,16 +156,7 @@ public class LibreOfficeTransformationIT
         testFile(MIMETYPE_TSV                                  ,"tsv"  ,"sample.tsv")
     ).collect(toMap(TestFileInfo::getPath, identity()));
 
-    public LibreOfficeTransformationIT(final Pair<TestFileInfo, TestFileInfo> entry)
-    {
-        sourceFile = entry.getLeft().getPath();
-        targetExtension = entry.getRight().getExtension();
-        sourceMimetype = entry.getLeft().getMimeType();
-        targetMimetype = entry.getRight().getMimeType();
-    }
-
-    @Parameterized.Parameters
-    public static Set<Pair<TestFileInfo, TestFileInfo>> engineTransformations()
+    public static Stream<Pair<TestFileInfo, TestFileInfo>> engineTransformations()
     {
         return Stream
             .of(
@@ -213,13 +196,16 @@ public class LibreOfficeTransformationIT
 
                 allTargets("quick.msg", txtTarget)
                 )
-            .flatMap(identity())
-            .collect(toSet());
+            .flatMap(identity());
     }
 
-    @Test
-    public void testTransformation()
+    @ParameterizedTest
+    public void testTransformation(final Pair<TestFileInfo, TestFileInfo> entry)
     {
+        final String sourceFile = entry.getLeft().getPath();
+        final String targetExtension = entry.getRight().getExtension();
+        final String sourceMimetype = entry.getLeft().getMimeType();
+        final String targetMimetype = entry.getRight().getMimeType();
         final String descriptor = format("Transform ({0}, {1} -> {2}, {3})",
             sourceFile, sourceMimetype, targetMimetype, targetExtension);
         try

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
@@ -57,11 +57,6 @@
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
@@ -51,15 +51,12 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@ExtendWith(SpringExtension.class)
 // Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
 // currently only MiscController.class
 @WebMvcTest()

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
@@ -57,7 +57,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in the application context,
 // currently only MiscController.class
 @WebMvcTest()
 public class MiscControllerTest extends AbstractTransformerControllerTest

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -35,9 +35,9 @@ import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_OPENXML_WORD
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_PDF;
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_RFC822;
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_TEXT_PLAIN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,17 +49,17 @@ import java.nio.file.Files;
 import org.alfresco.transform.client.model.TransformRequest;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(MiscController.class)
 public class MiscControllerTest extends AbstractTransformerControllerTest
 {
@@ -72,7 +72,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
 
     protected static final String ENGINE_CONFIG_NAME = "misc_engine_config.json";
 
-    @Before
+    @BeforeEach
     public void before() throws Exception
     {
         sourceMimetype = MIMETYPE_HTML;
@@ -152,8 +152,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             null,
             null,
             readTestFile("eml"));
-        assertTrue("Content from eml transform didn't contain expected value. ",
-            result.getResponse().getContentAsString().contains(expected));
+        assertTrue(result.getResponse().getContentAsString().contains(expected),
+            "Content from eml transform didn't contain expected value. ");
     }
 
     /**
@@ -173,8 +173,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
                 null, readTestFile("spanish.eml"));
 
         String contentResult = new String(result.getResponse().getContentAsByteArray(), UTF_8);
-        assertTrue("Content from eml transform didn't contain expected value. ",
-            contentResult.contains(expected));
+        assertTrue(contentResult.contains(expected),
+            "Content from eml transform didn't contain expected value. ");
     }
 
     /**
@@ -194,8 +194,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             null,
             null,
             readTestFile("attachment.eml"));
-        assertTrue("Content from eml transform didn't contain expected value. ",
-            result.getResponse().getContentAsString().contains(expected));
+        assertTrue(result.getResponse().getContentAsString().contains(expected),
+            "Content from eml transform didn't contain expected value. ");
         assertFalse(result.getResponse().getContentAsString().contains(notExpected));
     }
 
@@ -215,8 +215,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             null,
             null,
             readTestFile("alternative.eml"));
-        assertTrue("Content from eml transform didn't contain expected value. ",
-            result.getResponse().getContentAsString().contains(expected));
+        assertTrue(result.getResponse().getContentAsString().contains(expected),
+            "Content from eml transform didn't contain expected value. ");
     }
 
     /**
@@ -235,8 +235,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             null,
             null,
             readTestFile("nested.alternative.eml"));
-        assertTrue("Content from eml transform didn't contain expected value. ",
-            result.getResponse().getContentAsString().contains(expected));
+        assertTrue(result.getResponse().getContentAsString().contains(expected),
+            "Content from eml transform didn't contain expected value. ");
     }
 
     /**
@@ -269,7 +269,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
                 null,
                 readTestFile("eml"));
         String metadata = result.getResponse().getContentAsString();
-        assertEquals("Metadata extract", expected, metadata);
+        assertEquals(expected, metadata, "Metadata extract");
     }
 
     /**
@@ -301,7 +301,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
                 extractMapping,
                 readTestFile("eml"));
         String metadata = result.getResponse().getContentAsString();
-        assertEquals("Option metadata extract", expected, metadata);
+        assertEquals(expected, metadata, "Option metadata extract");
     }
 
     /**
@@ -350,7 +350,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
 
         String contentResult = new String(result.getResponse().getContentAsByteArray(),
             targetEncoding);
-        assertTrue("The content did not include \"" + expected, contentResult.contains(expected));
+        assertTrue(contentResult.contains(expected), "The content did not include \"" + expected);
     }
 
     @Test
@@ -380,7 +380,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
 
         String contentResult = new String(result.getResponse().getContentAsByteArray(),
             targetEncoding);
-        assertTrue("The content did not include \"" + expected, contentResult.contains(expected));
+        assertTrue(contentResult.contains(expected), "The content did not include \"" + expected);
     }
 
     @Test
@@ -399,8 +399,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
             null,
             content);
 
-        assertEquals("Returned content should be empty for an empty source file", 0,
-            result.getResponse().getContentLength());
+        assertEquals(0, result.getResponse().getContentLength(),
+            "Returned content should be empty for an empty source file");
     }
 
     @Test
@@ -435,7 +435,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
         expected = clean(expected);
         String actual = clean(textWriter.toString());
 
-        assertEquals("The content did not match.", expected, actual);
+        assertEquals(expected, actual, "The content did not match.");
     }
 
     @Test
@@ -443,8 +443,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
     {
         MvcResult result = sendRequest("numbers", null, MIMETYPE_IWORK_NUMBERS,
             "jpeg", MIMETYPE_IMAGE_JPEG, null, null, null, readTestFile("pages"));
-        assertTrue("Expected image content but content is empty.",
-            result.getResponse().getContentLengthLong() > 0L);
+        assertTrue(result.getResponse().getContentLengthLong() > 0L,
+            "Expected image content but content is empty.");
     }
 
     @Test
@@ -452,8 +452,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
     {
         MvcResult result = sendRequest("numbers", null, MIMETYPE_IWORK_NUMBERS,
             "jpeg", MIMETYPE_IMAGE_JPEG, null, null, null, readTestFile("numbers"));
-        assertTrue("Expected image content but content is empty.",
-            result.getResponse().getContentLengthLong() > 0L);
+        assertTrue(result.getResponse().getContentLengthLong() > 0L,
+            "Expected image content but content is empty.");
     }
 
     @Test
@@ -461,8 +461,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
     {
         MvcResult result = sendRequest("key", null, MIMETYPE_IWORK_KEYNOTE,
             "jpeg", MIMETYPE_IMAGE_JPEG, null, null, null, readTestFile("key"));
-        assertTrue("Expected image content but content is empty.",
-            result.getResponse().getContentLengthLong() > 0L);
+        assertTrue(result.getResponse().getContentLengthLong() > 0L,
+            "Expected image content but content is empty.");
     }
 
     //    @Test
@@ -471,8 +471,8 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
     {
         MvcResult result = sendRequest("docx", null, MIMETYPE_OPENXML_WORDPROCESSING,
             "jpeg", MIMETYPE_IMAGE_JPEG, null, null, null, readTestFile("docx"));
-        assertTrue("Expected image content but content is empty.",
-            result.getResponse().getContentLengthLong() > 0L);
+        assertTrue(result.getResponse().getContentLengthLong() > 0L,
+            "Expected image content but content is empty.");
     }
 
     private MvcResult sendRequest(String sourceExtension,

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
@@ -60,7 +60,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(MiscController.class)
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// currently only MiscController.class
+@WebMvcTest()
 public class MiscControllerTest extends AbstractTransformerControllerTest
 {
     @Autowired

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscMetadataExtractsIT.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscMetadataExtractsIT.java
@@ -33,6 +33,9 @@ import static org.alfresco.transformer.TestFileInfo.testFile;
 
 import java.util.stream.Stream;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 /**
  * Metadata integration tests in the Misc T-Engine.
  *
@@ -41,8 +44,15 @@ import java.util.stream.Stream;
 public class MiscMetadataExtractsIT extends AbstractMetadataExtractsIT
 {
 
+    @ParameterizedTest
+    @MethodSource("engineTransformations")
     @Override
-    protected Stream<TestFileInfo> engineTransformations() 
+    public void testTransformation(TestFileInfo testFileInfo)
+    {
+        super.testTransformation(testFileInfo);
+    }
+    
+    private static Stream<TestFileInfo> engineTransformations() 
     {
         return Stream.of(
                 // HtmlMetadataExtractor

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscMetadataExtractsIT.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscMetadataExtractsIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,38 +26,27 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_HTML;
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_RFC822;
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_XHTML;
 import static org.alfresco.transformer.TestFileInfo.testFile;
+
+import java.util.stream.Stream;
 
 /**
  * Metadata integration tests in the Misc T-Engine.
  *
  * @author adavis
  */
-@RunWith(Parameterized.class)
 public class MiscMetadataExtractsIT extends AbstractMetadataExtractsIT
 {
-    public MiscMetadataExtractsIT(TestFileInfo testFileInfo)
-    {
-        super(testFileInfo);
-    }
 
-    @Parameterized.Parameters
-    public static List<TestFileInfo> engineTransformations()
+    @Override
+    protected Stream<TestFileInfo> engineTransformations() 
     {
         return Stream.of(
                 // HtmlMetadataExtractor
-                testFile(MIMETYPE_HTML, "html", "quick.html"),
-                testFile(MIMETYPE_XHTML, "xhtml", "quick.xhtml.alf"), // avoid the license header check on xhtml
+                testFile(MIMETYPE_HTML, "html", "quick.html"), testFile(MIMETYPE_XHTML, "xhtml", "quick.xhtml.alf"), // avoid the license header check on xhtml
 
                 // RFC822MetadataExtractor
                 testFile(MIMETYPE_RFC822, "eml", "quick.eml"),
@@ -67,6 +56,6 @@ public class MiscMetadataExtractsIT extends AbstractMetadataExtractsIT
                 testFile(MIMETYPE_RFC822, "eml", "quick.spanish.eml"),
                 testFile(MIMETYPE_HTML, "html", "quick.japanese.html")
 
-        ).collect(toList());
+        );
     }
 }

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscMetadataExtractsIT.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscMetadataExtractsIT.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Metadata integration tests in the Misc T-Engine.
  *
  * @author adavis
+ * @author dedwards
  */
 public class MiscMetadataExtractsIT extends AbstractMetadataExtractsIT
 {

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscQueueTransformServiceIT.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscQueueTransformServiceIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -32,11 +32,8 @@ import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_TEXT_PLAIN;
 import java.util.UUID;
 
 import org.alfresco.transform.client.model.TransformRequest;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
                 properties = {"activemq.url=nio://localhost:61616"})
 public class MiscQueueTransformServiceIT extends AbstractQueueTransformServiceIT

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscTransformerHttpRequestTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscTransformerHttpRequestTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,11 +26,11 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
+/**
+ * Tests MiscController with a server test harness.
+ */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class MiscTransformerHttpRequestTest extends AbstractHttpRequestTest
 {

--- a/alfresco-transform-misc/alfresco-transform-misc/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc/pom.xml
@@ -71,9 +71,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/alfresco-transform-misc/alfresco-transform-misc/src/test/java/org/alfresco/transformer/transformers/HtmlParserContentTransformerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc/src/test/java/org/alfresco/transformer/transformers/HtmlParserContentTransformerTest.java
@@ -26,7 +26,7 @@
  */
 package org.alfresco.transformer.transformers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.alfresco.transformer.transformers.StringExtractingContentTransformer.SOURCE_ENCODING;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HtmlParserContentTransformerTest
 {

--- a/alfresco-transform-misc/alfresco-transform-misc/src/test/java/org/alfresco/transformer/transformers/TextToPdfContentTransformerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc/src/test/java/org/alfresco/transformer/transformers/TextToPdfContentTransformerTest.java
@@ -28,8 +28,8 @@ package org.alfresco.transformer.transformers;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -39,13 +39,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.alfresco.transformer.util.RequestParamMap.PAGE_LIMIT;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TextToPdfContentTransformerTest
 {
     TextToPdfContentTransformer transformer = new TextToPdfContentTransformer();
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         transformer.setStandardFont("Times-Roman");
@@ -121,8 +121,8 @@ public class TextToPdfContentTransformerTest
         String roundTrip = clean(textWriter.toString());
 
         assertEquals(
-            "Incorrect text in PDF when starting from text in " + encoding,
-            checkText, roundTrip
+            checkText, roundTrip,
+            "Incorrect text in PDF when starting from text in " + encoding
         );
 
         sourceFile.delete();

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
@@ -57,11 +57,6 @@
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
@@ -86,7 +86,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Super class includes tests for the AbstractTransformerController.
  */
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(AlfrescoPdfRendererController.class)
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// currently only AlfrescoPdfRendererController.class
+@WebMvcTest()
 public class AlfrescoPdfRendererControllerTest extends AbstractTransformerControllerTest
 {
 

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
@@ -66,7 +66,6 @@ import org.alfresco.transformer.model.FileRefEntity;
 import org.alfresco.transformer.model.FileRefResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,7 +76,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -85,7 +83,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Test the AlfrescoPdfRendererController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@ExtendWith(SpringExtension.class)
 // Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
 // currently only AlfrescoPdfRendererController.class
 @WebMvcTest()

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,11 +26,10 @@
  */
 package org.alfresco.transformer;
 
-import static org.alfresco.transformer.executors.RuntimeExec.ExecutionResult;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
@@ -56,15 +55,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import javax.annotation.PostConstruct;
+
 import org.alfresco.transform.client.model.TransformReply;
 import org.alfresco.transform.client.model.TransformRequest;
 import org.alfresco.transformer.executors.PdfRendererCommandExecutor;
 import org.alfresco.transformer.executors.RuntimeExec;
+import org.alfresco.transformer.executors.RuntimeExec.ExecutionResult;
 import org.alfresco.transformer.model.FileRefEntity;
 import org.alfresco.transformer.model.FileRefResponse;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,17 +77,15 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import javax.annotation.PostConstruct;
 
 /**
  * Test the AlfrescoPdfRendererController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(AlfrescoPdfRendererController.class)
 public class AlfrescoPdfRendererControllerTest extends AbstractTransformerControllerTest
 {
@@ -115,7 +115,7 @@ public class AlfrescoPdfRendererControllerTest extends AbstractTransformerContro
     @Autowired
     protected AbstractTransformerController controller;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException
     {
         setFields();
@@ -156,7 +156,7 @@ public class AlfrescoPdfRendererControllerTest extends AbstractTransformerContro
         when(mockTransformCommand.execute(any(), anyLong())).thenAnswer(
             (Answer<RuntimeExec.ExecutionResult>) invocation -> {
                 Map<String, String> actualProperties = invocation.getArgument(0);
-                assertEquals("There should be 3 properties", 3, actualProperties.size());
+                assertEquals(3, actualProperties.size(), "There should be 3 properties");
 
                 String actualOptions = actualProperties.get("options");
                 String actualSource = actualProperties.get("source");
@@ -167,9 +167,9 @@ public class AlfrescoPdfRendererControllerTest extends AbstractTransformerContro
                 assertNotNull(actualTarget);
                 if (expectedSourceSuffix != null)
                 {
-                    assertTrue("The source file \"" + actualSource +
-                               "\" should have ended in \"" + expectedSourceSuffix + "\"",
-                        actualSource.endsWith(expectedSourceSuffix));
+                    assertTrue(actualSource.endsWith(expectedSourceSuffix),
+                        "The source file \"" + actualSource +
+                               "\" should have ended in \"" + expectedSourceSuffix + "\"");
                     actualSource = actualSource.substring(0,
                         actualSource.length() - expectedSourceSuffix.length());
                 }
@@ -177,14 +177,14 @@ public class AlfrescoPdfRendererControllerTest extends AbstractTransformerContro
                 assertNotNull(actualOptions);
                 if (expectedOptions != null)
                 {
-                    assertEquals("expectedOptions", expectedOptions, actualOptions);
+                    assertEquals(expectedOptions, actualOptions,"expectedOptions");
                 }
 
                 Long actualTimeout = invocation.getArgument(1);
                 assertNotNull(actualTimeout);
                 if (expectedTimeout != null)
                 {
-                    assertEquals("expectedTimeout", expectedTimeout, actualTimeout);
+                    assertEquals(expectedTimeout, actualTimeout,"expectedTimeout");
                 }
 
                 // Copy a test file into the target file location if it exists
@@ -200,8 +200,8 @@ public class AlfrescoPdfRendererControllerTest extends AbstractTransformerContro
 
                 // Check the supplied source file has not been changed.
                 byte[] actualSourceFileBytes = Files.readAllBytes(new File(actualSource).toPath());
-                assertTrue("Source file is not the same",
-                    Arrays.equals(expectedSourceFileBytes, actualSourceFileBytes));
+                assertTrue(Arrays.equals(expectedSourceFileBytes, actualSourceFileBytes),
+                    "Source file is not the same");
 
                 return mockExecutionResult;
             });

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
@@ -83,7 +83,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Test the AlfrescoPdfRendererController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in the application context,
 // currently only AlfrescoPdfRendererController.class
 @WebMvcTest()
 public class AlfrescoPdfRendererControllerTest extends AbstractTransformerControllerTest

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererHttpRequestTest.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererHttpRequestTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,15 +26,12 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Tests AlfrescoPdfRendererController with a server test harness.
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class AlfrescoPdfRendererHttpRequestTest extends AbstractHttpRequestTest
 {

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererQueueTransformServiceIT.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererQueueTransformServiceIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -32,15 +32,12 @@ import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_PDF;
 import java.util.UUID;
 
 import org.alfresco.transform.client.model.TransformRequest;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Lucian Tuca
  * created on 15/01/2019
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
                 properties = {"activemq.url=nio://localhost:61616"})
 public class AlfrescoPdfRendererQueueTransformServiceIT extends AbstractQueueTransformServiceIT

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererTransformationIT.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererTransformationIT.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,8 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
-
-import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Cezar Leahu
@@ -63,9 +60,9 @@ public class AlfrescoPdfRendererTransformationIT
         testFile("application/illustrator","ai","quickCS5.ai")
     ).collect(toMap(TestFileInfo::getPath, identity()));
 
-    public static Set<String> engineTransformations()
+    public static Stream<String> engineTransformations()
     {
-        return ImmutableSet.of(
+        return Stream.of(
             "quick.pdf",
             "quickCS3.ai",
             "quickCS5.ai"

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererTransformationIT.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererTransformationIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -31,17 +31,16 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.alfresco.transformer.EngineClient.sendTRequest;
 import static org.alfresco.transformer.TestFileInfo.testFile;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
@@ -52,7 +51,6 @@ import com.google.common.collect.ImmutableSet;
 /**
  * @author Cezar Leahu
  */
-@RunWith(Parameterized.class)
 public class AlfrescoPdfRendererTransformationIT
 {
     private static final Logger logger = LoggerFactory.getLogger(
@@ -65,16 +63,6 @@ public class AlfrescoPdfRendererTransformationIT
         testFile("application/illustrator","ai","quickCS5.ai")
     ).collect(toMap(TestFileInfo::getPath, identity()));
 
-    private final String sourceFile;
-    private final String sourceMimetype;
-
-    public AlfrescoPdfRendererTransformationIT(String sourceFile)
-    {
-        this.sourceFile = sourceFile;
-        this.sourceMimetype = TEST_FILES.get(sourceFile).getMimeType();
-    }
-
-    @Parameterized.Parameters
     public static Set<String> engineTransformations()
     {
         return ImmutableSet.of(
@@ -84,9 +72,12 @@ public class AlfrescoPdfRendererTransformationIT
         );
     }
 
-    @Test
-    public void testTransformation()
+    @ParameterizedTest
+    @MethodSource("engineTransformations")
+    public void testTransformation(String sourceFile)
     {
+        final String sourceMimetype = TEST_FILES.get(sourceFile).getMimeType();
+
         final String descriptor = format("Transform ({0}, {1} -> {2}, {3})",
             sourceFile, sourceMimetype, "image/png", "png");
 
@@ -94,7 +85,7 @@ public class AlfrescoPdfRendererTransformationIT
         {
             final ResponseEntity<Resource> response = sendTRequest(ENGINE_URL, sourceFile, sourceMimetype,
                 "image/png", "png");
-            assertEquals(descriptor, OK, response.getStatusCode());
+            assertEquals(OK, response.getStatusCode(),descriptor);
         }
         catch (Exception e)
         {

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -137,13 +137,6 @@
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox-tools</artifactId>
         </dependency>
-
-        <!-- Test dependenciues -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
@@ -26,40 +26,6 @@
  */
 package org.alfresco.transformer;
 
-import org.alfresco.transform.client.model.TransformReply;
-import org.alfresco.transform.client.model.TransformRequest;
-import org.alfresco.transformer.executors.RuntimeExec;
-import org.alfresco.transformer.model.FileRefEntity;
-import org.alfresco.transformer.model.FileRefResponse;
-import org.alfresco.transformer.probes.ProbeTestTransform;
-import org.apache.poi.ooxml.POIXMLProperties;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.stubbing.Answer;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import javax.servlet.http.HttpServletRequest;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import static java.nio.file.Files.readAllBytes;
 import static org.alfresco.transformer.executors.Tika.ARCHIVE;
 import static org.alfresco.transformer.executors.Tika.CSV;
@@ -96,10 +62,10 @@ import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_XML;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_ZIP;
 import static org.alfresco.transformer.util.RequestParamMap.INCLUDE_CONTENTS;
 import static org.alfresco.transformer.util.RequestParamMap.NOT_EXTRACT_BOOKMARK_TEXT;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
@@ -116,11 +82,46 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.util.StringUtils.getFilenameExtension;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.alfresco.transform.client.model.TransformReply;
+import org.alfresco.transform.client.model.TransformRequest;
+import org.alfresco.transformer.executors.RuntimeExec;
+import org.alfresco.transformer.model.FileRefEntity;
+import org.alfresco.transformer.model.FileRefResponse;
+import org.alfresco.transformer.probes.ProbeTestTransform;
+import org.apache.poi.ooxml.POIXMLProperties;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
 /**
  * Test the TikaController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(TikaController.class)
 public class TikaControllerTest extends AbstractTransformerControllerTest
 {
@@ -148,7 +149,7 @@ public class TikaControllerTest extends AbstractTransformerControllerTest
     private String targetEncoding = "UTF-8";
     private String targetMimetype = MIMETYPE_TEXT_PLAIN;
 
-    @Before
+    @BeforeEach
     public void before()
     {
         sourceExtension = "pdf";
@@ -180,7 +181,7 @@ public class TikaControllerTest extends AbstractTransformerControllerTest
         when(mockTransformCommand.execute(any(), anyLong())).thenAnswer(
             (Answer<RuntimeExec.ExecutionResult>) invocation -> {
                 Map<String, String> actualProperties = invocation.getArgument(0);
-                assertEquals("There should be 3 properties", 3, actualProperties.size());
+                assertEquals(3, actualProperties.size(),"There should be 3 properties");
 
                 String actualOptions = actualProperties.get("options");
                 String actualSource = actualProperties.get("source");
@@ -191,9 +192,8 @@ public class TikaControllerTest extends AbstractTransformerControllerTest
                 assertNotNull(actualTarget);
                 if (expectedSourceSuffix != null)
                 {
-                    assertTrue(
-                        "The source file \"" + actualSource + "\" should have ended in \"" + expectedSourceSuffix + "\"",
-                        actualSource.endsWith(expectedSourceSuffix));
+                    assertTrue(actualSource.endsWith(expectedSourceSuffix),
+                        "The source file \"" + actualSource + "\" should have ended in \"" + expectedSourceSuffix + "\"");
                     actualSource = actualSource.substring(0,
                         actualSource.length() - expectedSourceSuffix.length());
                 }
@@ -201,14 +201,14 @@ public class TikaControllerTest extends AbstractTransformerControllerTest
                 assertNotNull(actualOptions);
                 if (expectedOptions != null)
                 {
-                    assertEquals("expectedOptions", expectedOptions, actualOptions);
+                    assertEquals(expectedOptions, actualOptions, "expectedOptions");
                 }
 
                 Long actualTimeout = invocation.getArgument(1);
                 assertNotNull(actualTimeout);
                 if (expectedTimeout != null)
                 {
-                    assertEquals("expectedTimeout", expectedTimeout, actualTimeout);
+                    assertEquals(expectedTimeout, actualTimeout, "expectedTimeout");
                 }
 
                 // Copy a test file into the target file location if it exists
@@ -224,8 +224,8 @@ public class TikaControllerTest extends AbstractTransformerControllerTest
 
                 // Check the supplied source file has not been changed.
                 byte[] actualSourceFileBytes = readAllBytes(new File(actualSource).toPath());
-                assertArrayEquals("Source file is not the same", expectedSourceFileBytes,
-                    actualSourceFileBytes);
+                assertArrayEquals(expectedSourceFileBytes, actualSourceFileBytes, 
+                    "Source file is not the same");
 
                 return mockExecutionResult;
             });
@@ -261,8 +261,8 @@ public class TikaControllerTest extends AbstractTransformerControllerTest
                                       "attachment; filename*= UTF-8''quick." + this.targetExtension)).
                                       andReturn();
         String content = result.getResponse().getContentAsString();
-        assertTrue("The content did not include \"" + expectedContentContains,
-            content.contains(expectedContentContains));
+        assertTrue(content.contains(expectedContentContains),
+            "The content did not include \"" + expectedContentContains);
     }
 
     @Override

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
@@ -122,7 +122,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Super class includes tests for the AbstractTransformerController.
  */
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(TikaController.class)
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// currently only TikaController.class
+@WebMvcTest()
 public class TikaControllerTest extends AbstractTransformerControllerTest
 {
     private static final String ENGINE_CONFIG_NAME = "tika_engine_config.json";

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
@@ -119,7 +119,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Test the TikaController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
+// Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in the application context,
 // currently only TikaController.class
 @WebMvcTest()
 public class TikaControllerTest extends AbstractTransformerControllerTest

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
@@ -101,7 +101,6 @@ import org.apache.poi.ooxml.POIXMLProperties;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,7 +110,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -121,7 +119,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  * Test the TikaController without a server.
  * Super class includes tests for the AbstractTransformerController.
  */
-@ExtendWith(SpringExtension.class)
 // Specifying class for @WebMvcTest() will break AIO tests, without specifying it will use all controllers in context, 
 // currently only TikaController.class
 @WebMvcTest()

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaHttpRequestTest.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaHttpRequestTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -28,19 +28,16 @@ package org.alfresco.transformer;
 
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.LinkedMultiValueMap;
 
 /**
  * Tests TikaController with a server test harness.
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class TikaHttpRequestTest extends AbstractHttpRequestTest
 {

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaMetadataExtractsIT.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaMetadataExtractsIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,13 +26,6 @@
  */
 package org.alfresco.transformer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_APP_DWG;
 import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_OUTLOOK_MSG;
 import static org.alfresco.transformer.TestFileInfo.testFile;
@@ -74,21 +67,29 @@ import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_WORD;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_XML;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_ZIP;
 
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 /**
  * Metadata integration tests in the Tika T-Engine.
  *
  * @author adavis
+ * @author dedwards
  */
-@RunWith(Parameterized.class)
 public class TikaMetadataExtractsIT extends AbstractMetadataExtractsIT
 {
-    public TikaMetadataExtractsIT(TestFileInfo testFileInfo)
+
+    @ParameterizedTest
+    @MethodSource("engineTransformations")
+    @Override
+    public void testTransformation(TestFileInfo testFileInfo)
     {
-        super(testFileInfo);
+        super.testTransformation(testFileInfo);
     }
 
-    @Parameterized.Parameters
-    public static List<TestFileInfo> engineTransformations()
+    private static Stream<TestFileInfo> engineTransformations()
     {
         // The following files are the ones tested in the content repository.
         // There are many more mimetypes supported by these extractors.
@@ -528,6 +529,6 @@ public class TikaMetadataExtractsIT extends AbstractMetadataExtractsIT
                 // cause OutOfMemory in Tika Note - doesn't use extractFromMimetype
                 testFile(MIMETYPE_OPENXML_SPREADSHEET, "xlsx", "dmsu1332-reproduced.xlsx")
 
-        ).collect(toList());
+        );
     }
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaQueueTransformServiceIT.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaQueueTransformServiceIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -32,15 +32,12 @@ import static org.alfresco.transform.client.model.Mimetype.MIMETYPE_TEXT_PLAIN;
 import java.util.UUID;
 
 import org.alfresco.transform.client.model.TransformRequest;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Lucian Tuca
  * created on 15/01/2019
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
                 properties = {"activemq.url=nio://localhost:61616"})
 public class TikaQueueTransformServiceIT extends AbstractQueueTransformServiceIT

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaTransformationIT.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaTransformationIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -28,31 +28,27 @@ package org.alfresco.transformer;
 
 import static java.text.MessageFormat.format;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toSet;
 import static org.alfresco.transformer.EngineClient.sendTRequest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.apache.commons.lang3.tuple.Triple;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 
-import com.google.common.collect.ImmutableMap;
-
 /**
  * @author Cezar Leahu
  */
-@RunWith(Parameterized.class)
 public class TikaTransformationIT
 {
     private static final Logger logger = LoggerFactory.getLogger(TikaTransformationIT.class);
@@ -63,15 +59,16 @@ public class TikaTransformationIT
         "xhtml", "application/xhtml+xml",
         "xml", "text/xml");
 
-    private final String sourceFile;
-    private final String targetExtension;
-    private final String targetMimetype;
-    private final String sourceMimetype;
+    
 
-    public TikaTransformationIT(final Triple<String, String, String> entry)
+    @ParameterizedTest
+    @MethodSource("engineTransformations")
+    public void testTransformation(Triple<String, String, String> entry)
     {
-        sourceFile = entry.getLeft();
-        targetExtension = entry.getMiddle();
+        final String sourceFile = entry.getLeft();
+        final String sourceMimetype = entry.getRight();
+        final String targetExtension = entry.getMiddle();
+        String targetMimetype;
         //Single test to cover pdf-->csv
         if (sourceFile.contains("pdf") && targetExtension.contains("csv"))
         {
@@ -81,7 +78,31 @@ public class TikaTransformationIT
         {
             targetMimetype = extensionMimetype.get(entry.getMiddle());
         }
-        sourceMimetype = entry.getRight();
+        
+
+        final String descriptor = format("Transform ({0}, {1} -> {2}, {3})",
+            sourceFile, sourceMimetype, targetMimetype, targetExtension);
+        try
+        {
+            final ResponseEntity<Resource> response = sendTRequest(ENGINE_URL, sourceFile, null,
+                targetMimetype, targetExtension, ImmutableMap.of(
+                    "targetEncoding", "UTF-8",
+                    "sourceMimetype", sourceMimetype));
+            assertEquals(OK, response.getStatusCode(), descriptor);
+        }
+        catch (Exception e)
+        {
+            fail(descriptor + " exception: " + e.getMessage());
+        }
+    }
+
+    private static Stream<Triple<String, String, String>> allTargets(final String sourceFile,
+        final String sourceMimetype)
+    {
+        return extensionMimetype
+            .keySet()
+            .stream()
+            .map(k -> Triple.of(sourceFile, k, sourceMimetype));
     }
 
     // TODO unit tests for the following file types (for which is difficult to find file samples):
@@ -89,9 +110,7 @@ public class TikaTransformationIT
     //  *.cpio (application/x-cpio)
     //  *.cdf (application/x-netcdf) 
     //  *.hdf (application/x-hdf)
-
-    @Parameterized.Parameters
-    public static Set<Triple<String, String, String>> engineTransformations()
+    public static Stream<Triple<String, String, String>> engineTransformations()
     {
         return Stream
             .of(
@@ -152,35 +171,6 @@ public class TikaTransformationIT
                 allTargets("quick.z", "application/x-compress"),
                 allTargets("quick.csv", "text/csv"),
                 allTargets("quick.tar.gz", "application/x-gzip"))
-            .flatMap(identity())
-            .collect(toSet());
-    }
-
-    @Test
-    public void testTransformation()
-    {
-        final String descriptor = format("Transform ({0}, {1} -> {2}, {3})",
-            sourceFile, sourceMimetype, targetMimetype, targetExtension);
-        try
-        {
-            final ResponseEntity<Resource> response = sendTRequest(ENGINE_URL, sourceFile, null,
-                targetMimetype, targetExtension, ImmutableMap.of(
-                    "targetEncoding", "UTF-8",
-                    "sourceMimetype", sourceMimetype));
-            assertEquals(descriptor, OK, response.getStatusCode());
-        }
-        catch (Exception e)
-        {
-            fail(descriptor + " exception: " + e.getMessage());
-        }
-    }
-
-    private static Stream<Triple<String, String, String>> allTargets(final String sourceFile,
-        final String sourceMimetype)
-    {
-        return extensionMimetype
-            .keySet()
-            .stream()
-            .map(k -> Triple.of(sourceFile, k, sourceMimetype));
+            .flatMap(identity());
     }
 }

--- a/alfresco-transform-tika/alfresco-transform-tika/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/pom.xml
@@ -47,6 +47,10 @@
                     <groupId>org.quartz-scheduler</groupId>
                     <artifactId>quartz</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/alfresco-transformer-base/pom.xml
+++ b/alfresco-transformer-base/pom.xml
@@ -74,11 +74,6 @@
             <artifactId>google-collections</artifactId>
             <version>1.0</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractHttpRequestTest.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractHttpRequestTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractHttpRequestTest.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractHttpRequestTest.java
@@ -26,12 +26,12 @@
  */
 package org.alfresco.transformer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.test.util.AssertionErrors.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
@@ -29,7 +29,8 @@ package org.alfresco.transformer;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 
@@ -39,6 +40,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static java.text.MessageFormat.format;
 import static org.alfresco.transformer.EngineClient.sendTRequest;
@@ -60,19 +62,18 @@ public abstract class AbstractMetadataExtractsIT
     // These are normally variable, hence the lowercase.
     private static final String targetMimetype = MIMETYPE_METADATA_EXTRACT;
     private static final String targetExtension = "json";
-    protected final String sourceMimetype;
-    protected final String sourceFile;
+
     private final ObjectMapper jsonObjectMapper = new ObjectMapper();
 
-    public AbstractMetadataExtractsIT(TestFileInfo testFileInfo)
-    {
-        sourceMimetype = testFileInfo.getMimeType();
-        sourceFile = testFileInfo.getPath();
-    }
+    abstract protected Stream<TestFileInfo> engineTransformations();
 
-    @Test
-    public void testTransformation()
+    @ParameterizedTest
+    @MethodSource("engineTransformations")
+    public void testTransformation(TestFileInfo testFileInfo)
     {
+        final String sourceMimetype = testFileInfo.getMimeType();
+        final String sourceFile = testFileInfo.getPath();
+
         final String descriptor = format("Transform ({0}, {1} -> {2}, {3})",
                 sourceFile, sourceMimetype, targetMimetype, targetExtension);
 

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
@@ -47,11 +47,30 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 
 /**
- * Super class of metadata integration tests. Sub classes should add the list of test files to
- * {@code @Parameterized.Parameters public static Set<TestFileInfo> engineTransformations()} and provide
- * expected json files (&lt;sourceFilename>"_metadata.json") as resources on the classpath.
+ * Super class of metadata integration tests. Sub classes should provide the following:
+ * <p>
+ * <ul>
+ * <li>A method providing a 
+ * Stream of test files: {@code public static Stream<TestFileInfo> engineTransformations()}; </li>
+ * <li> Provide expected json files (&lt;sourceFilename>"_metadata.json") as resources on the classpath.</li>
+ * <li> Override the method {@code testTransformation(TestFileInfo testFileInfo)} such that it calls 
+ * the super method as a {@code @ParameterizedTest} for example:</li> </ul>
+ * <pre>
+ * &#64;ParameterizedTest
+ * 
+ * &#64;MethodSource("engineTransformations")
+ * 
+ * &#64;Override
+
+ * public void testTransformation(TestFileInfo testFileInfo)
+ * 
+ * { 
+ *      super.testTransformation(TestFileInfo testFileInfo)
+ * }
+ * </pre> 
  *
  * @author adavis
+ * @author dedwards
  */
 public abstract class AbstractMetadataExtractsIT
 {

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
@@ -28,7 +28,8 @@ package org.alfresco.transformer;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 
@@ -42,8 +43,8 @@ import java.util.Map;
 import static java.text.MessageFormat.format;
 import static org.alfresco.transformer.EngineClient.sendTRequest;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_METADATA_EXTRACT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.http.HttpStatus.OK;
 
 /**
@@ -79,7 +80,7 @@ public abstract class AbstractMetadataExtractsIT
         {
             final ResponseEntity<Resource> response = sendTRequest(ENGINE_URL, sourceFile,
                     sourceMimetype, targetMimetype, targetExtension);
-            assertEquals(descriptor, OK, response.getStatusCode());
+            assertEquals(OK, response.getStatusCode(), descriptor);
 
             String metadataFilename = sourceFile + "_metadata.json";
             Map<String, Serializable> actualMetadata = readMetadata(response.getBody().getInputStream());
@@ -87,8 +88,8 @@ public abstract class AbstractMetadataExtractsIT
             jsonObjectMapper.writerWithDefaultPrettyPrinter().writeValue(actualMetadataFile, actualMetadata);
 
             Map<String, Serializable> expectedMetadata = readExpectedMetadata(metadataFilename, actualMetadataFile);
-            assertEquals("The metadata did not match the expected value. It has been saved in "+actualMetadataFile.getAbsolutePath(),
-                    expectedMetadata, actualMetadata);
+            assertEquals(expectedMetadata, actualMetadata, 
+                "The metadata did not match the expected value. It has been saved in "+actualMetadataFile.getAbsolutePath());
             actualMetadataFile.delete();
         }
         catch (Exception e)

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
@@ -26,13 +26,12 @@
  */
 package org.alfresco.transformer;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.core.io.Resource;
-import org.springframework.http.ResponseEntity;
+import static java.text.MessageFormat.format;
+import static org.alfresco.transformer.EngineClient.sendTRequest;
+import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_METADATA_EXTRACT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.springframework.http.HttpStatus.OK;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,14 +39,12 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Stream;
 
-import static java.text.MessageFormat.format;
-import static org.alfresco.transformer.EngineClient.sendTRequest;
-import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_METADATA_EXTRACT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.springframework.http.HttpStatus.OK;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 
 /**
  * Super class of metadata integration tests. Sub classes should add the list of test files to

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
@@ -65,10 +65,7 @@ public abstract class AbstractMetadataExtractsIT
 
     private final ObjectMapper jsonObjectMapper = new ObjectMapper();
 
-    abstract protected Stream<TestFileInfo> engineTransformations();
-
-    @ParameterizedTest
-    @MethodSource("engineTransformations")
+    
     public void testTransformation(TestFileInfo testFileInfo)
     {
         final String sourceMimetype = testFileInfo.getMimeType();

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractQueueTransformServiceIT.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractQueueTransformServiceIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractQueueTransformServiceIT.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractQueueTransformServiceIT.java
@@ -26,25 +26,22 @@
  */
 package org.alfresco.transformer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javax.jms.Queue;
 
 import org.alfresco.transform.client.model.TransformReply;
 import org.alfresco.transform.client.model.TransformRequest;
 import org.apache.activemq.command.ActiveMQQueue;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jms.core.JmsTemplate;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Lucian Tuca
  * created on 15/01/2019
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(properties = {"activemq.url=nio://localhost:61616"})
 public abstract class AbstractQueueTransformServiceIT
 {

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractTransformerControllerTest.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractTransformerControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/QueueTransformServiceTest.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/QueueTransformServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/QueueTransformServiceTest.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/QueueTransformServiceTest.java
@@ -46,8 +46,8 @@ import org.alfresco.transformer.messaging.TransformMessageConverter;
 import org.alfresco.transformer.messaging.TransformReplySender;
 import org.apache.activemq.command.ActiveMQObjectMessage;
 import org.apache.activemq.command.ActiveMQQueue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -67,7 +67,7 @@ public class QueueTransformServiceTest
     @InjectMocks
     private QueueTransformService queueTransformService;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
         MockitoAnnotations.initMocks(this);


### PR DESCRIPTION
Due to the recent upgrade to SpringBoot 2.4.1, no tests have been able to execute.

This PR is to upgrade to Junit 5 to re-enable to the tests in Travis. 