### PR TITLE
ATS-1196: Update Spring Boot Starter to 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.1</version>
+        <version>2.4.2</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Bumps spring-boot-starter-parent from 2.4.1 to 2.4.2.
