### PR TITLE
Include throwable cause in TransformException

### DIFF
--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/executors/Transformer.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/executors/Transformer.java
@@ -76,11 +76,11 @@ public interface Transformer
         }
         catch (IllegalArgumentException e)
         {
-            throw new TransformException(BAD_REQUEST.value(), getMessage(e));
+            throw new TransformException(BAD_REQUEST.value(), getMessage(e), e);
         }
         catch (Exception e)
         {
-            throw new TransformException(INTERNAL_SERVER_ERROR.value(), getMessage(e));
+            throw new TransformException(INTERNAL_SERVER_ERROR.value(), getMessage(e), e);
         }
         if (!targetFile.exists())
         {


### PR DESCRIPTION
When an exception occurs in transformations we will get the message and and internal server error. However the cause is lost. In my case I got a NullPointerException in the core-aio transform, but no info where it originated from. With this change the cause will be added to the new TransformException.