### PR TITLE
MNT-20626 XML files having UTF-16LE and UTF-16BE can't be previewed

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -275,7 +275,7 @@ public class AIOTransformRegistryTest
         int cutoff = pageLimit * pageLength;
         for (int i = 1; i <= lines; i++)
         {
-            sb.append(i);
+            sb.append(Integer.toString(i));
             sb.append(" I must not talk in class or feed my homework to my cat.\n");
             if (i == cutoff)
                 checkText = sb.toString();

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/test/java/org/alfresco/transformer/MiscControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -409,7 +409,7 @@ public class MiscControllerTest extends AbstractTransformerControllerTest
         StringBuilder sb = new StringBuilder();
         for (int i = 1; i <= 5; i++)
         {
-            sb.append(i);
+            sb.append(Integer.toString(i));
             sb.append(" I must not talk in class or feed my homework to my cat.\n");
         }
         sb.append("\nBart\n");

--- a/alfresco-transform-misc/alfresco-transform-misc/src/test/java/org/alfresco/transformer/transformers/TextToPdfContentTransformerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc/src/test/java/org/alfresco/transformer/transformers/TextToPdfContentTransformerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
@@ -39,10 +40,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.alfresco.transformer.util.RequestParamMap.PAGE_LIMIT;
+import static org.alfresco.transformer.util.RequestParamMap.SOURCE_ENCODING;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TextToPdfContentTransformerTest
 {
+    public static final Character REVERSE_BOM = Character.valueOf('\uFFFE');
+    public static final Character NORMAL_BOM = Character.valueOf('\uFEFF');
     TextToPdfContentTransformer transformer = new TextToPdfContentTransformer();
 
     @Before
@@ -76,39 +81,130 @@ public class TextToPdfContentTransformerTest
         transformTextAndCheckPageLength(50);
     }
 
+    @Test
+    public void test1UTF16BigEndianBomBigEndianChars() throws Exception
+    {
+        // 1. BOM indicates BE (fe then ff) + chars appear to be BE (as first byte read tends to be a zero)
+        //    Expected with UTF-16. Some systems use BE and other like Windows and Mac used LE
+        transformTextAndCheck("UTF-16", "UTF-16BE", NORMAL_BOM,
+                "fe ff 00 31 00 20 00 49");
+        transformTextAndCheck("UTF-16", "UTF-16", null,
+                "fe ff 00 31 00 20 00 49");
+
+        transformTextAndCheck("UTF-16BE", "UTF-16", null,
+                "fe ff 00 31 00 20 00 49");
+        transformTextAndCheck("UTF-16LE", "UTF-16", null,
+                "fe ff 00 31 00 20 00 49");
+    }
+
+    @Test
+    public void test2UTF16LittleEndianBomLittleEndianChars() throws Exception
+    {
+        // 2. BOM indicates LE (ff then fe) + chars appear to be LE (as second byte read tends to be a zero)
+        //    Expected with UTF-16. Some systems use BE and other like Windows and Mac used LE
+        transformTextAndCheck("UTF-16", "UTF-16LE", REVERSE_BOM,
+                "ff fe 31 00 20 00 49 00");
+    }
+
+    @Test
+    public void test3UTF16NoBomBigEndianChars() throws Exception
+    {
+        // 3. No BOM + chars appear to be BE (as first byte read tends to be a zero)
+        //    Expected with UTF-16BE
+        transformTextAndCheck("UTF-16", "UTF-16BE", null,
+                "00 31 00 20 00 49");
+    }
+
+    @Test
+    public void test4UTF16NoBomLittleEndianChars() throws Exception
+    {
+        // 4. No BOM + chars appear to be LE (as second byte read tends to be a zero)
+        //    Expected with UTF-16LE
+        transformTextAndCheck("UTF-16", "UTF-16LE", null,
+                "31 00 20 00 49 00");
+    }
+
+    @Test
+    public void test5UTF16BigEndianBomLittleEndianChars() throws Exception
+    {
+        // 5. BOM indicates BE (fe then ff) + chars appear to be LE (as second byte read tends to be a zero)
+        //    SOMETHING IS WRONG, BUT USE LE!!!!
+        transformTextAndCheck("UTF-16", "UTF-16LE", NORMAL_BOM,
+                "fe ff 31 00 20 00 49 00");
+    }
+
+    @Test
+    public void test6UTF16LittleEndianBomBigEndianChars() throws Exception
+    {
+        // 6. BOM indicates LE (ff then fe) + chars appear to be BE (as first byte read tends to be a zero)
+        //    SOMETHING IS WRONG, BUT USE BE!!!!
+        transformTextAndCheck("UTF-16", "UTF-16BE", REVERSE_BOM,
+                "ff fe 00 31 00 20 00 49");
+    }
+
+    private void transformTextAndCheck(String encoding, String actualSourceEncoding,
+                                       Character byteOrderMark, String expectedByteOrder) throws Exception
+    {
+        transformTextAndCheckPageLength(-1, encoding, actualSourceEncoding, byteOrderMark, expectedByteOrder);
+    }
+
     private void transformTextAndCheckPageLength(int pageLimit) throws Exception
+    {
+        transformTextAndCheck("UTF-8", "UTF-8", null, null);
+    }
+
+    private void transformTextAndCheckPageLength(int pageLimit, String encoding, String actualSourceEncoding,
+                                                 Character byteOrderMark, String expectedByteOrder) throws Exception
+    {
+        StringBuilder sb = new StringBuilder();
+        String checkText = createTestText(pageLimit, byteOrderMark, sb);
+        String text = sb.toString();
+
+        File sourceFile = File.createTempFile("AlfrescoTestSource_", ".txt");
+        writeToFile(sourceFile, text, actualSourceEncoding);
+        checkFileBytes(sourceFile, expectedByteOrder);
+
+        transformTextAndCheck(sourceFile, encoding, checkText, String.valueOf(pageLimit));
+    }
+
+    private String createTestText(int pageLimit, Character byteOrderMark, StringBuilder sb)
     {
         int pageLength = 32;
         int lines = (pageLength + 10) * ((pageLimit > 0) ? pageLimit : 1);
-        StringBuilder sb = new StringBuilder();
+        if (byteOrderMark != null)
+        {
+            sb.append(byteOrderMark);
+        }
         String checkText = null;
         int cutoff = pageLimit * pageLength;
         for (int i = 1; i <= lines; i++)
         {
-            sb.append(i);
+            sb.append(Integer.toString(i));
             sb.append(" I must not talk in class or feed my homework to my cat.\n");
             if (i == cutoff)
+            {
                 checkText = sb.toString();
+            }
         }
         sb.append("\nBart\n");
+
         String text = sb.toString();
-        checkText = (checkText == null) ? clean(text) : clean(checkText);
-        transformTextAndCheck(text, "UTF-8", checkText, String.valueOf(pageLimit));
+        checkText = checkText == null ? clean(text) : clean(checkText);
+        checkText =  byteOrderMark != null ? checkText.substring(1) : checkText;
+
+        return checkText;
     }
 
-    private void transformTextAndCheck(String text, String encoding, String checkText,
+    private void transformTextAndCheck(File sourceFile, String encoding, String checkText,
         String pageLimit) throws Exception
     {
-        // Get a reader for the text
-        File sourceFile = File.createTempFile("AlfrescoTestSource_", ".txt");
-        writeToFile(sourceFile, text, encoding);
-
         // And a temp writer
         File targetFile = File.createTempFile("AlfrescoTestTarget_", ".pdf");
 
         // Transform to PDF
         Map<String, String> parameters = new HashMap<>();
         parameters.put(PAGE_LIMIT, pageLimit);
+        parameters.put(SOURCE_ENCODING, encoding);
         transformer.transform("text/plain", "application/pdf", parameters, sourceFile, targetFile);
 
         // Read back in the PDF and check it
@@ -144,5 +240,53 @@ public class TextToPdfContentTransformerTest
         {
             ow.append(content);
         }
+    }
+
+    /**
+     * Check the first few bytes in the source file match what we planed to use later as test data.
+     */
+    private void checkFileBytes(File sourceFile, String expectedByteOrder) throws Exception
+    {
+        if (expectedByteOrder != null)
+        {
+            byte[] expectedBytes = hexToBytes(expectedByteOrder); // new BigInteger(expectedByteOrder,16).toByteArray();
+            int l = expectedBytes.length;
+            byte[] actualBytes = new byte[l];
+
+            FileInputStream is = new FileInputStream(sourceFile);
+            is.read(actualBytes, 0, l);
+            String actualByteOrder = bytesToHex(actualBytes);
+            assertEquals("The sourceFile does not contain the expected bytes", expectedByteOrder, actualByteOrder);
+        }
+    }
+
+    private byte[] hexToBytes(String hexString)
+    {
+        hexString = hexString.replaceAll(" *", "");
+        int len = hexString.length() / 2;
+        byte[] bytes = new byte[len];
+        for (int j=0, i=0; i<len; i++)
+        {
+            int firstDigit = Character.digit(hexString.charAt(j++), 16);
+            int secondDigit = Character.digit(hexString.charAt(j++), 16);
+            bytes[i] = (byte)((firstDigit << 4) + secondDigit);
+        }
+        return bytes;
+    }
+
+    private String bytesToHex(byte[] bytes)
+    {
+        StringBuffer sb = new StringBuffer();
+        int len = bytes.length;
+        for (int i=0; i<len; i++)
+        {
+            if (sb.length() > 0)
+            {
+                sb.append(' ');
+            }
+            sb.append(Character.forDigit((bytes[i] >> 4) & 0xF, 16));
+            sb.append(Character.forDigit((bytes[i] & 0xF), 16));
+        }
+        return sb.toString();
     }
 }

--- a/alfresco-transform-misc/alfresco-transform-misc/src/test/java/org/alfresco/transformer/transformers/TextToPdfContentTransformerTest.java
+++ b/alfresco-transform-misc/alfresco-transform-misc/src/test/java/org/alfresco/transformer/transformers/TextToPdfContentTransformerTest.java
@@ -49,8 +49,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TextToPdfContentTransformerTest
 {
-    public static final Character REVERSE_BOM = Character.valueOf('\uFFFE');
-    public static final Character NORMAL_BOM = Character.valueOf('\uFEFF');
     TextToPdfContentTransformer transformer = new TextToPdfContentTransformer();
 
     @BeforeEach
@@ -93,6 +91,7 @@ public class TextToPdfContentTransformerTest
         transformTextAndCheck("UTF-16", true, true, expectedByteOrder);
         transformTextAndCheck("UTF-16", true, true, expectedByteOrder);
         transformTextAndCheck("UTF-16BE", true, true, expectedByteOrder);
+        transformTextAndCheck("UTF-16LE", true, true, expectedByteOrder);
     }
 
     @Test
@@ -283,8 +282,6 @@ public class TextToPdfContentTransformerTest
                             bytes[1] = aByte;
                         }
                     }
-                    // 6. Expected :ff fe 00 31 00 20 00 49
-                    //    Actual   :fe ff 31 00 20 00 49 00
                     int len = l - off;
                     if (len > 0)
                     {

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <image.tag>latest</image.tag>
-        <dependency.pdfbox.version>2.0.19</dependency.pdfbox.version>
+        <dependency.pdfbox.version>2.0.22</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.1</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
         <dependency.alfresco-transform-model.version>1.0.2.11</dependency.alfresco-transform-model.version>


### PR DESCRIPTION
* Introduce more flexible reading of UTF-16 data, where there may be a BOM where the
  spec says there should not be one or the BOM is clearly wrong when looking at the
  following characters. The https://en.wikipedia.org/wiki/UTF-16 write up is nice an clear.
* Includes identical correction in data setup in AIOTransformRegistryTest and
  MicsControllerTest for a problem found in TextToPdfContentTransformerTest.
* Includes upgrade to latest pdfbox: 2.0.22