### PR TITLE
ATS-863: Update to latest Java Base Image on CentOS 8 (& Open JDK 11.0.10)

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
@@ -9,7 +9,7 @@ FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:f498c3106940e6f
 
 ENV APACHE_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/Apache%202.0.txt
 
-ARG IMAGEMAGICK_VERSION=7.0.10-11
+ARG IMAGEMAGICK_VERSION=7.0.10-59
 ENV IMAGEMAGICK_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}/imagemagick-distribution-${IMAGEMAGICK_VERSION}-linux.rpm
 ENV IMAGEMAGICK_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}/imagemagick-distribution-${IMAGEMAGICK_VERSION}-libs-linux.rpm
 ENV IMAGEMAGICK_DEP_RPM_URL=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
@@ -5,7 +5,7 @@
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-7-9da90416ab19
+FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:f498c3106940e6fccc5d52e6c3e6e8ff237a3ad689bf737b2ca6fdff1a2109cc
 
 ENV APACHE_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/Apache%202.0.txt
 

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-7-9da90416ab19
+FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:f498c3106940e6fccc5d52e6c3e6e8ff237a3ad689bf737b2ca6fdff1a2109cc
 
 ARG IMAGEMAGICK_VERSION=7.0.10-11
 

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:f498c3106940e6fccc5d52e6c3e6e8ff237a3ad689bf737b2ca6fdff1a2109cc
 
-ARG IMAGEMAGICK_VERSION=7.0.10-11
+ARG IMAGEMAGICK_VERSION=7.0.10-59
 
 ENV IMAGEMAGICK_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}/imagemagick-distribution-${IMAGEMAGICK_VERSION}-linux.rpm
 ENV IMAGEMAGICK_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}/imagemagick-distribution-${IMAGEMAGICK_VERSION}-libs-linux.rpm

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/Dockerfile
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # LibreOffice is from The Document Foundation. See the license at https://www.libreoffice.org/download/license/ or in /libreoffice.txt.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-7-9da90416ab19
+FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:f498c3106940e6fccc5d52e6c3e6e8ff237a3ad689bf737b2ca6fdff1a2109cc
 
 ARG LIBREOFFICE_VERSION=6.3.5
 

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/Dockerfile
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/Dockerfile
@@ -1,6 +1,6 @@
 # Image provides a container in which to run miscellaneous transformations for Alfresco Content Services.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-7-9da90416ab19
+FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:f498c3106940e6fccc5d52e6c3e6e8ff237a3ad689bf737b2ca6fdff1a2109cc
 
 ENV APACHE_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/Apache%202.0.txt
 ENV JAVA_OPTS=""

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/Dockerfile
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-7-9da90416ab19
+FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:f498c3106940e6fccc5d52e6c3e6e8ff237a3ad689bf737b2ca6fdff1a2109cc
 
 ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/1.1/alfresco-pdf-renderer-1.1-linux.tgz
 ENV PDFIUM_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/pdfium.txt

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tika is from Apache. See the license at http://www.apache.org/licenses/LICENSE-2.0.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-7-9da90416ab19
+FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:f498c3106940e6fccc5d52e6c3e6e8ff237a3ad689bf737b2ca6fdff1a2109cc
 
 ENV APACHE_LICENSE_FILE=https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/Apache%202.0.txt
 ENV JAVA_OPTS=""


### PR DESCRIPTION
- to resolve 2 medium (at time of writing) in quay.io
- update to CentOS 7 to 8 (aligned with Repo decision)