### PR TITLE
ATS: Update libraries (DependABot) etc - fix jackson core/data-bind version mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency.alfresco-transform-model.version>1.3.1</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.16.1</dependency.activemq.version>
         <dependency.jackson.version>2.12.1</dependency.jackson.version>
-        <dependency.jackson-databind.version>2.10.5.1</dependency.jackson-databind.version>
+        <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>
         <dependency.junit.version>4.13.1</dependency.junit.version>
         <dependency.cxf.version>3.4.3</dependency.cxf.version>
         <dependency.tika.version>1.26</dependency.tika.version>


### PR DESCRIPTION
- small PR prior to DependABot prompted updates, such as:
-- https://github.com/Alfresco/alfresco-transform-core/pull/351#pullrequestreview-621417662
-- https://github.com/Alfresco/alfresco-transform-core/pull/368
-- ...

- in most cases, these versions should match
-- only exception is previous occasions where data-bind specific version was released ahead of core