### PR TITLE
ATS: Tweak Java Base Image references

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
@@ -5,7 +5,7 @@
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
+FROM alfresco/alfresco-base-java:11.0.11-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
 
 ARG EXIFTOOL_VERSION=12.25
 ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
+FROM alfresco/alfresco-base-java:11.0.11-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
 
 ARG IMAGEMAGICK_VERSION=7.0.10-59
 

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/Dockerfile
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # LibreOffice is from The Document Foundation. See the license at https://www.libreoffice.org/download/license/ or in /libreoffice.txt.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
+FROM alfresco/alfresco-base-java:11.0.11-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
 
 ARG LIBREOFFICE_VERSION=6.3.5
 

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/Dockerfile
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/Dockerfile
@@ -1,6 +1,6 @@
 # Image provides a container in which to run miscellaneous transformations for Alfresco Content Services.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
+FROM alfresco/alfresco-base-java:11.0.11-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
 
 ENV JAVA_OPTS=""
 

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/Dockerfile
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
+FROM alfresco/alfresco-base-java:11.0.11-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
 
 ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/1.1/alfresco-pdf-renderer-1.1-linux.tgz
 ENV JAVA_OPTS=""

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tika is from Apache. See the license at http://www.apache.org/licenses/LICENSE-2.0.
 
-FROM alfresco/alfresco-base-java:11.0.10-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
+FROM alfresco/alfresco-base-java:11.0.11-openjdk-centos-8@sha256:7d4177162080b8f18b3c7b9f59fb86a3c74c8e82aa329ab4e3878d660bc16195
 
 ARG EXIFTOOL_VERSION=12.25
 ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}


### PR DESCRIPTION
- note: sha256 id is used
- update prefix moniker to document the JDK version (& match quay.io tag name)