### PR TITLE
ACS-1677 Provide file extension from JMS request if missing in SFS

### DIFF
--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -230,7 +230,7 @@ public abstract class AbstractTransformerController implements TransformControll
         File sourceFile;
         try
         {
-            sourceFile = loadSourceFile(request.getSourceReference());
+            sourceFile = loadSourceFile(request.getSourceReference(), request.getSourceExtension());
         }
         catch (TransformException e)
         {
@@ -358,9 +358,10 @@ public abstract class AbstractTransformerController implements TransformControll
      * Loads the file with the specified sourceReference from Alfresco Shared File Store
      *
      * @param sourceReference reference to the file in Alfresco Shared File Store
+     * @param sourceExtension default extension if the file in Alfresco Shared File Store has none
      * @return the file containing the source content for the transformation
      */
-    private File loadSourceFile(final String sourceReference)
+    private File loadSourceFile(final String sourceReference, final String sourceExtension)
     {
         ResponseEntity<Resource> responseEntity = alfrescoSharedFileStoreClient
             .retrieveFile(sourceReference);
@@ -369,7 +370,7 @@ public abstract class AbstractTransformerController implements TransformControll
         HttpHeaders headers = responseEntity.getHeaders();
         String filename = getFilenameFromContentDisposition(headers);
 
-        String extension = getFilenameExtension(filename);
+        String extension = getFilenameExtension(filename) != null ? getFilenameExtension(filename) : sourceExtension;
         MediaType contentType = headers.getContentType();
         long size = headers.getContentLength();
 


### PR DESCRIPTION
This will provide the file downloaded from Share File Store with the expected file extension provided in the `TransformRequest`, instead of null, if it is not present in the Share File Store response.
