### PR TITLE
ATS-864: Switch from fabric8 to docker mvn plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 99
   ignore:
-  - dependency-name: io.fabric8:fabric8-maven-plugin
-    versions:
-    - "> 4.4.0, < 4.5"
   registries:
   - maven-alfresco-internal
 - package-ecosystem: docker

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
@@ -125,15 +125,14 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>before-integration-tests</id>
+                                <id>integration-tests</id>
                                 <goals>
-                                    <goal>stop</goal>
                                     <goal>start</goal>
+                                    <goal>stop</goal>
                                 </goals>
                                 <configuration>
                                     <images>
                                         <image>
-                                            <alias>activemq</alias>
                                             <name>alfresco/alfresco-activemq:5.16.1</name>
                                             <run>
                                                 <hostname>activemq</hostname>
@@ -155,7 +154,6 @@
                                             </run>
                                         </image>
                                         <image>
-                                            <alias>aio</alias>
                                             <name>${image.name}:${image.tag}</name>
                                             <run>
                                                 <ports>
@@ -180,13 +178,6 @@
                                     </images>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>after-integration-tests</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -203,6 +194,7 @@
                         <executions>
                             <execution>
                                 <id>build-image</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -260,9 +252,9 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>push-image</id>
                                 <phase>install</phase>
                                 <goals>
+                                    <goal>build</goal>
                                     <goal>push</goal>
                                 </goals>
                             </execution>
@@ -306,7 +298,6 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>build-push-image</id>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
@@ -137,13 +137,23 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.36.0</version>
+                        <extensions>true</extensions>
                         <configuration>
+                            <apiVersion>1.29</apiVersion>
+                            <imagePullPolicy>Always</imagePullPolicy>
+                            <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
+                            <!--<dockerHost>tcp://127.0.0.1:2376</dockerHost>-->
                             <images>
                                 <image>
                                     <alias>activemq</alias>
                                     <name>alfresco/alfresco-activemq:5.16.1</name>
                                     <run>
                                         <hostname>activemq</hostname>
+                                        <network>
+                                            <name>transform</name>
+                                            <alias>activemq</alias>
+                                        </network>
                                         <ports>
                                             <port>8161:8161</port>
                                             <port>5672:5672</port>
@@ -187,6 +197,23 @@
                                 </image>
                             </images>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>before-integration-tests</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>after-integration-tests</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
@@ -198,7 +198,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <image>
@@ -232,7 +232,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <!-- QuayIO image -->
@@ -285,9 +285,9 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <configuration combine.self="override">
-                            <images>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images combine.self="override">
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
@@ -137,7 +137,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.36.0</version>
+                        <version>0.36.1</version>
                         <extensions>true</extensions>
                         <configuration>
                             <apiVersion>1.29</apiVersion>

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-core-aio-boot</artifactId>
     <name>Alfresco Core All-In-One Transformer Spring Boot</name>
-    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -104,29 +102,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
-
 
     <profiles>
         <profile>
@@ -135,76 +117,68 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.36.1</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <apiVersion>1.29</apiVersion>
-                            <imagePullPolicy>Always</imagePullPolicy>
-                            <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
-                            <!--<dockerHost>tcp://127.0.0.1:2376</dockerHost>-->
-                            <images>
-                                <image>
-                                    <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.16.1</name>
-                                    <run>
-                                        <hostname>activemq</hostname>
-                                        <network>
-                                            <name>transform</name>
-                                            <alias>activemq</alias>
-                                        </network>
-                                        <ports>
-                                            <port>8161:8161</port>
-                                            <port>5672:5672</port>
-                                            <port>61616:61616</port>
-                                        </ports>
-                                        <wait>
-                                            <log>Apache ActiveMQ 5.16.1 .* started</log>
-                                            <time>20000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
-
-                                <image>
-                                    <alias>aio</alias>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <run>
-                                        <ports>
-                                            <port>8090:8090</port>
-                                        </ports>
-                                        <wait>
-                                            <http>
-                                                <url>http://localhost:8090/transform/config</url>
-                                                <method>GET</method>
-                                                <status>200...299</status>
-                                            </http>
-                                            <time>300000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>before-integration-tests</id>
-                                <phase>pre-integration-test</phase>
                                 <goals>
                                     <goal>stop</goal>
                                     <goal>start</goal>
                                 </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <alias>activemq</alias>
+                                            <name>alfresco/alfresco-activemq:5.16.1</name>
+                                            <run>
+                                                <hostname>activemq</hostname>
+                                                <ports>
+                                                    <port>8161:8161</port>
+                                                    <port>5672:5672</port>
+                                                    <port>61616:61616</port>
+                                                </ports>
+                                                <wait>
+                                                    <log>Apache ActiveMQ .* started</log>
+                                                    <time>20000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                        <image>
+                                            <alias>aio</alias>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <run>
+                                                <ports>
+                                                    <port>8090:8090</port>
+                                                </ports>
+                                                <wait>
+                                                    <http>
+                                                        <url>http://localhost:8090/transform/config</url>
+                                                        <method>GET</method>
+                                                        <status>200...299</status>
+                                                    </http>
+                                                    <time>300000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>after-integration-tests</id>
@@ -226,26 +200,25 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>build-image</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <build>
+                                                <contextDir>${project.basedir}</contextDir>
+                                                <buildOptions>
+                                                    <squash>true</squash>
+                                                </buildOptions>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -267,7 +240,7 @@
                                     <name>${image.name}:${image.tag}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -277,7 +250,7 @@
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -286,13 +259,6 @@
                             </images>
                         </configuration>
                         <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
                             <execution>
                                 <id>push-image</id>
                                 <phase>install</phase>
@@ -314,13 +280,13 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
-                            <images combine.self="override">
+                            <images>
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -330,7 +296,7 @@
                                  <image>
                                     <name>${image.name}:${project.version}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -341,7 +307,6 @@
                         <executions>
                             <execution>
                                 <id>build-push-image</id>
-                                <phase>deploy</phase>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/pom.xml
@@ -3,7 +3,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-core-aio</artifactId>
     <name>Alfresco Core All-In-One Transformer</name>
-    <packaging>jar</packaging>
 
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
@@ -56,20 +55,11 @@
         </dependency>
     </dependencies>
 
-
     <build>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
@@ -172,7 +172,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <image>
@@ -206,7 +206,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>fdocker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <!-- QuayIO image -->
@@ -259,9 +259,9 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <configuration combine.self="override">
-                            <images>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images combine.self="override">
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
@@ -100,15 +100,14 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>before-integration-tests</id>
+                                <id>integration-tests</id>
                                 <goals>
-                                    <goal>stop</goal>
                                     <goal>start</goal>
+                                    <goal>stop</goal>
                                 </goals>
                                 <configuration>
                                     <images>
                                         <image>
-                                            <alias>activemq</alias>
                                             <name>alfresco/alfresco-activemq:5.16.1</name>
                                             <run>
                                                 <hostname>activemq</hostname>
@@ -130,7 +129,6 @@
                                             </run>
                                         </image>
                                         <image>
-                                            <alias>imagemagick</alias>
                                             <name>${image.name}:${image.tag}</name>
                                             <run>
                                                 <ports>
@@ -155,13 +153,6 @@
                                     </images>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>after-integration-tests</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -178,6 +169,7 @@
                         <executions>
                             <execution>
                                 <id>build-image</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -235,15 +227,9 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>build-image</id>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>push-image</id>
                                 <phase>install</phase>
                                 <goals>
+                                    <goal>build</goal>
                                     <goal>push</goal>
                                 </goals>
                             </execution>
@@ -287,7 +273,6 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>build-push-image</id>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
@@ -206,7 +206,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fdocker-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <!-- QuayIO image -->

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-imagemagick-boot</artifactId>
     <name>Alfresco ImageMagick Transformer Spring Boot</name>
-    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -66,13 +66,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -80,16 +73,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -101,7 +85,6 @@
         </plugins>
     </build>
 
-
     <profiles>
         <profile>
             <id>docker-it-setup</id>
@@ -109,58 +92,77 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.16.1</name>
-                                    <run>
-                                        <hostname>activemq</hostname>
-                                        <ports>
-                                            <port>8161:8161</port>
-                                            <port>5672:5672</port>
-                                            <port>61616:61616</port>
-                                        </ports>
-                                        <wait>
-                                            <log>Apache ActiveMQ 5.16.1 .* started</log>
-                                            <time>20000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
-
-                                <image>
-                                    <alias>imagemagick</alias>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <run>
-                                        <ports>
-                                            <port>8090:8090</port>
-                                        </ports>
-                                        <wait>
-                                            <http>
-                                                <url>http://localhost:8090/transform/config</url>
-                                                <method>GET</method>
-                                                <status>200...299</status>
-                                            </http>
-                                            <time>300000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>before-integration-tests</id>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <alias>activemq</alias>
+                                            <name>alfresco/alfresco-activemq:5.16.1</name>
+                                            <run>
+                                                <hostname>activemq</hostname>
+                                                <ports>
+                                                    <port>8161:8161</port>
+                                                    <port>5672:5672</port>
+                                                    <port>61616:61616</port>
+                                                </ports>
+                                                <wait>
+                                                    <log>Apache ActiveMQ 5.16.1 .* started</log>
+                                                    <time>20000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                        <image>
+                                            <alias>imagemagick</alias>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <run>
+                                                <ports>
+                                                    <port>8090:8090</port>
+                                                </ports>
+                                                <wait>
+                                                    <http>
+                                                        <url>http://localhost:8090/transform/config</url>
+                                                        <method>GET</method>
+                                                        <status>200...299</status>
+                                                    </http>
+                                                    <time>300000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>after-integration-tests</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -173,26 +175,25 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>build-image</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <build>
+                                                <contextDir>${project.basedir}</contextDir>
+                                                <buildOptions>
+                                                    <squash>true</squash>
+                                                </buildOptions>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -214,7 +215,7 @@
                                     <name>${image.name}:${image.tag}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -224,7 +225,7 @@
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -235,7 +236,6 @@
                         <executions>
                             <execution>
                                 <id>build-image</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -261,13 +261,13 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
-                            <images combine.self="override">
+                            <images>
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -277,7 +277,7 @@
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -288,7 +288,6 @@
                         <executions>
                             <execution>
                                 <id>build-push-image</id>
-                                <phase>deploy</phase>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick/pom.xml
@@ -3,7 +3,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-imagemagick</artifactId>
     <name>Alfresco ImageMagick Transformer</name>
-    <packaging>jar</packaging>
 
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
@@ -18,7 +17,6 @@
             <artifactId>alfresco-transformer-base</artifactId>
             <version>${project.version}</version>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -26,14 +24,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-libreoffice-boot</artifactId>
     <name>Alfresco LibreOffice Transformer Spring Boot </name>
-    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -74,13 +74,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -88,16 +81,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -109,7 +93,6 @@
         </plugins>
     </build>
 
-
     <profiles>
         <profile>
             <id>docker-it-setup</id>
@@ -117,58 +100,78 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.16.1</name>
-                                    <run>
-                                        <hostname>activemq</hostname>
-                                        <ports>
-                                            <port>8161:8161</port>
-                                            <port>5672:5672</port>
-                                            <port>61616:61616</port>
-                                        </ports>
-                                        <wait>
-                                            <log>Apache ActiveMQ 5.16.1 .* started</log>
-                                            <time>20000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
+                        <executions>
+                            <execution>
+                                <id>before-integration-tests</id>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <alias>activemq</alias>
+                                            <name>alfresco/alfresco-activemq:5.16.1</name>
+                                            <run>
+                                                <hostname>activemq</hostname>
+                                                <ports>
+                                                    <port>8161:8161</port>
+                                                    <port>5672:5672</port>
+                                                    <port>61616:61616</port>
+                                                </ports>
+                                                <wait>
+                                                    <log>Apache ActiveMQ 5.16.1 .* started</log>
+                                                    <time>20000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
 
-                                <image>
-                                    <alias>libreoffice</alias>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <run>
-                                        <ports>
-                                            <port>8090:8090</port>
-                                        </ports>
-                                        <wait>
-                                            <http>
-                                                <url>http://localhost:8090/transform/config</url>
-                                                <method>GET</method>
-                                                <status>200...299</status>
-                                            </http>
-                                            <time>300000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
+                                        <image>
+                                            <alias>libreoffice</alias>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <run>
+                                                <ports>
+                                                    <port>8090:8090</port>
+                                                </ports>
+                                                <wait>
+                                                    <http>
+                                                        <url>http://localhost:8090/transform/config</url>
+                                                        <method>GET</method>
+                                                        <status>200...299</status>
+                                                    </http>
+                                                    <time>300000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>after-integration-tests</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -181,26 +184,25 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>build-image</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <build>
+                                                <contextDir>${project.basedir}</contextDir>
+                                                <buildOptions>
+                                                    <squash>true</squash>
+                                                </buildOptions>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -222,7 +224,7 @@
                                     <name>${image.name}:${image.tag}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -232,7 +234,7 @@
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -241,13 +243,6 @@
                             </images>
                         </configuration>
                         <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
                             <execution>
                                 <id>push-image</id>
                                 <phase>install</phase>
@@ -269,13 +264,13 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
-                            <images combine.self="override">
+                            <images>
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -285,7 +280,7 @@
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -293,16 +288,6 @@
                                 </image>
                             </images>
                         </configuration>
-                        <executions>
-                            <execution>
-                                <id>build-push-image</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                    <goal>push</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
@@ -180,7 +180,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <image>
@@ -214,7 +214,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <!-- QuayIO image -->
@@ -267,9 +267,9 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <configuration combine.self="override">
-                            <images>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images combine.self="override">
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
@@ -108,15 +108,14 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>before-integration-tests</id>
+                                <id>integration-tests</id>
                                 <goals>
-                                    <goal>stop</goal>
                                     <goal>start</goal>
+                                    <goal>stop</goal>
                                 </goals>
                                 <configuration>
                                     <images>
                                         <image>
-                                            <alias>activemq</alias>
                                             <name>alfresco/alfresco-activemq:5.16.1</name>
                                             <run>
                                                 <hostname>activemq</hostname>
@@ -137,9 +136,7 @@
                                                 </wait>
                                             </run>
                                         </image>
-
                                         <image>
-                                            <alias>libreoffice</alias>
                                             <name>${image.name}:${image.tag}</name>
                                             <run>
                                                 <ports>
@@ -164,13 +161,6 @@
                                     </images>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>after-integration-tests</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -187,6 +177,7 @@
                         <executions>
                             <execution>
                                 <id>build-image</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -244,9 +235,9 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>push-image</id>
                                 <phase>install</phase>
                                 <goals>
+                                    <goal>build</goal>
                                     <goal>push</goal>
                                 </goals>
                             </execution>

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice/pom.xml
@@ -3,7 +3,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-libreoffice</artifactId>
     <name>Alfresco LibreOffice Transformer</name>
-    <packaging>jar</packaging>
 
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
@@ -18,12 +17,10 @@
             <artifactId>alfresco-transformer-base</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-jodconverter-core</artifactId>
@@ -44,15 +41,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-misc-boot</artifactId>
     <name>Alfresco Miscellaneous Transformer Spring Boot</name>
-    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -64,13 +62,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -78,16 +69,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -99,7 +81,6 @@
         </plugins>
     </build>
 
-
     <profiles>
         <profile>
             <id>docker-it-setup</id>
@@ -107,58 +88,71 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.16.1</name>
-                                    <run>
-                                        <hostname>activemq</hostname>
-                                        <ports>
-                                            <port>8161:8161</port>
-                                            <port>5672:5672</port>
-                                            <port>61616:61616</port>
-                                        </ports>
-                                        <wait>
-                                            <log>Apache ActiveMQ 5.16.1 .* started</log>
-                                            <time>20000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
+                        <executions>
+                            <execution>
+                                <id>before-integration-tests</id>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <alias>activemq</alias>
+                                            <name>alfresco/alfresco-activemq:5.16.1</name>
+                                            <run>
+                                                <hostname>activemq</hostname>
+                                                <ports>
+                                                    <port>8161:8161</port>
+                                                    <port>5672:5672</port>
+                                                    <port>61616:61616</port>
+                                                </ports>
+                                                <wait>
+                                                    <log>Apache ActiveMQ 5.16.1 .* started</log>
+                                                    <time>20000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
 
-                                <image>
-                                    <alias>misc</alias>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <run>
-                                        <ports>
-                                            <port>8090:8090</port>
-                                        </ports>
-                                        <wait>
-                                            <http>
-                                                <url>http://localhost:8090/transform/config</url>
-                                                <method>GET</method>
-                                                <status>200...299</status>
-                                            </http>
-                                            <time>300000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
+                                        <image>
+                                            <alias>misc</alias>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <run>
+                                                <ports>
+                                                    <port>8090:8090</port>
+                                                </ports>
+                                                <wait>
+                                                    <http>
+                                                        <url>http://localhost:8090/transform/config</url>
+                                                        <method>GET</method>
+                                                        <status>200...299</status>
+                                                    </http>
+                                                    <time>300000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -171,26 +165,25 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>build-image</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <build>
+                                                <contextDir>${project.basedir}</contextDir>
+                                                <buildOptions>
+                                                    <squash>true</squash>
+                                                </buildOptions>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -212,7 +205,7 @@
                                     <name>${image.name}:${image.tag}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -222,7 +215,7 @@
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -231,13 +224,6 @@
                             </images>
                         </configuration>
                         <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
                             <execution>
                                 <id>push-image</id>
                                 <phase>install</phase>
@@ -259,13 +245,13 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
-                            <images combine.self="override">
+                            <images>
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -275,7 +261,7 @@
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -283,16 +269,6 @@
                                 </image>
                             </images>
                         </configuration>
-                        <executions>
-                            <execution>
-                                <id>build-push-image</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                    <goal>push</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
@@ -96,15 +96,14 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>before-integration-tests</id>
+                                <id>integration-tests</id>
                                 <goals>
-                                    <goal>stop</goal>
                                     <goal>start</goal>
+                                    <goal>stop</goal>
                                 </goals>
                                 <configuration>
                                     <images>
                                         <image>
-                                            <alias>activemq</alias>
                                             <name>alfresco/alfresco-activemq:5.16.1</name>
                                             <run>
                                                 <hostname>activemq</hostname>
@@ -125,9 +124,7 @@
                                                 </wait>
                                             </run>
                                         </image>
-
                                         <image>
-                                            <alias>misc</alias>
                                             <name>${image.name}:${image.tag}</name>
                                             <run>
                                                 <ports>
@@ -168,6 +165,7 @@
                         <executions>
                             <execution>
                                 <id>build-image</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -225,9 +223,9 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>push-image</id>
                                 <phase>install</phase>
                                 <goals>
+                                    <goal>build</goal>
                                     <goal>push</goal>
                                 </goals>
                             </execution>

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
@@ -170,7 +170,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <image>
@@ -204,7 +204,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <!-- QuayIO image -->
@@ -257,9 +257,9 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <configuration combine.self="override">
-                            <images>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images combine.self="override">
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>

--- a/alfresco-transform-misc/alfresco-transform-misc/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc/pom.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-misc</artifactId>
     <name>Alfresco Miscellaneous Transformer</name>
-    <packaging>jar</packaging>
 
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
@@ -82,14 +80,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
@@ -96,15 +96,14 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>before-integration-tests</id>
+                                <id>integration-tests</id>
                                 <goals>
-                                    <goal>stop</goal>
                                     <goal>start</goal>
+                                    <goal>stop</goal>
                                 </goals>
                                 <configuration>
                                     <images>
                                         <image>
-                                            <alias>activemq</alias>
                                             <name>alfresco/alfresco-activemq:5.16.1</name>
                                             <run>
                                                 <hostname>activemq</hostname>
@@ -125,9 +124,7 @@
                                                 </wait>
                                             </run>
                                         </image>
-
                                         <image>
-                                            <alias>alfresco-pdf-renderer</alias>
                                             <name>${image.name}:${image.tag}</name>
                                             <run>
                                                 <ports>
@@ -152,13 +149,6 @@
                                     </images>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>after-integration-tests</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -175,6 +165,7 @@
                         <executions>
                             <execution>
                                 <id>build-image</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -232,9 +223,9 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>push-image</id>
                                 <phase>install</phase>
                                 <goals>
+                                    <goal>build</goal>
                                     <goal>push</goal>
                                 </goals>
                             </execution>
@@ -278,7 +269,6 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>build-push-image</id>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
@@ -1,10 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
-    
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-pdf-renderer-boot</artifactId>
     <name>Alfresco Pdf Renderer Spring Boot</name>
-    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -64,13 +62,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -78,16 +69,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -99,7 +81,6 @@
         </plugins>
     </build>
 
-
     <profiles>
         <profile>
             <id>docker-it-setup</id>
@@ -107,58 +88,78 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.16.1</name>
-                                    <run>
-                                        <hostname>activemq</hostname>
-                                        <ports>
-                                            <port>8161:8161</port>
-                                            <port>5672:5672</port>
-                                            <port>61616:61616</port>
-                                        </ports>
-                                        <wait>
-                                            <log>Apache ActiveMQ 5.16.1 .* started</log>
-                                            <time>20000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
+                        <executions>
+                            <execution>
+                                <id>before-integration-tests</id>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <alias>activemq</alias>
+                                            <name>alfresco/alfresco-activemq:5.16.1</name>
+                                            <run>
+                                                <hostname>activemq</hostname>
+                                                <ports>
+                                                    <port>8161:8161</port>
+                                                    <port>5672:5672</port>
+                                                    <port>61616:61616</port>
+                                                </ports>
+                                                <wait>
+                                                    <log>Apache ActiveMQ 5.16.1 .* started</log>
+                                                    <time>20000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
 
-                                <image>
-                                    <alias>alfresco-pdf-renderer</alias>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <run>
-                                        <ports>
-                                            <port>8090:8090</port>
-                                        </ports>
-                                        <wait>
-                                            <http>
-                                                <url>http://localhost:8090/transform/config</url>
-                                                <method>GET</method>
-                                                <status>200...299</status>
-                                            </http>
-                                            <time>300000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
+                                        <image>
+                                            <alias>alfresco-pdf-renderer</alias>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <run>
+                                                <ports>
+                                                    <port>8090:8090</port>
+                                                </ports>
+                                                <wait>
+                                                    <http>
+                                                        <url>http://localhost:8090/transform/config</url>
+                                                        <method>GET</method>
+                                                        <status>200...299</status>
+                                                    </http>
+                                                    <time>300000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>after-integration-tests</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -171,26 +172,25 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>build-image</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <build>
+                                                <contextDir>${project.basedir}</contextDir>
+                                                <buildOptions>
+                                                    <squash>true</squash>
+                                                </buildOptions>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -212,7 +212,7 @@
                                     <name>${image.name}:${image.tag}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -222,7 +222,7 @@
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -231,13 +231,6 @@
                             </images>
                         </configuration>
                         <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
                             <execution>
                                 <id>push-image</id>
                                 <phase>install</phase>
@@ -259,13 +252,13 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
-                            <images combine.self="override">
+                            <images>
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -275,7 +268,7 @@
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -286,7 +279,6 @@
                         <executions>
                             <execution>
                                 <id>build-push-image</id>
-                                <phase>deploy</phase>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
@@ -170,7 +170,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <image>
@@ -204,7 +204,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <!-- QuayIO image -->
@@ -257,9 +257,9 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <configuration combine.self="override">
-                            <images>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images combine.self="override">
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer/pom.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-pdf-renderer</artifactId>
     <name>Alfresco Pdf Renderer Transformer</name>
-    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -25,14 +25,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
         </plugins>
-    </build>      
+    </build>
 </project>

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-tika-boot</artifactId>
     <name>Alfresco Tika Transformer Spring Boot</name>
-    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -146,21 +146,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -169,7 +154,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -181,66 +165,85 @@
         </plugins>
     </build>
 
-
     <profiles>
         <profile>
-            <id>docker-it-setup</id>
+            <id>    docker-it-setup</id>
             <!-- raises an ActiveMq container for the Integration Tests -->
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>activemq</alias>
-                                    <name>alfresco/alfresco-activemq:5.16.1</name>
-                                    <run>
-                                        <hostname>activemq</hostname>
-                                        <ports>
-                                            <port>8161:8161</port>
-                                            <port>5672:5672</port>
-                                            <port>61616:61616</port>
-                                        </ports>
-                                        <wait>
-                                            <log>Apache ActiveMQ 5.16.1 .* started</log>
-                                            <time>20000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
+                        <executions>
+                            <execution>
+                                <id>before-integration-tests</id>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <alias>activemq</alias>
+                                            <name>alfresco/alfresco-activemq:5.16.1</name>
+                                            <run>
+                                                <hostname>activemq</hostname>
+                                                <ports>
+                                                    <port>8161:8161</port>
+                                                    <port>5672:5672</port>
+                                                    <port>61616:61616</port>
+                                                </ports>
+                                                <wait>
+                                                    <log>Apache ActiveMQ 5.16.1 .* started</log>
+                                                    <time>20000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
 
-                                <image>
-                                    <alias>tika</alias>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <run>
-                                        <ports>
-                                            <port>8090:8090</port>
-                                        </ports>
-                                        <wait>
-                                            <http>
-                                                <url>http://localhost:8090/transform/config</url>
-                                                <method>GET</method>
-                                                <status>200...299</status>
-                                            </http>
-                                            <time>300000</time>
-                                            <kill>500</kill>
-                                            <shutdown>100</shutdown>
-                                            <exec>
-                                                <preStop>kill 1</preStop>
-                                                <preStop>kill -9 1</preStop>
-                                            </exec>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
+                                        <image>
+                                            <alias>tika</alias>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <run>
+                                                <ports>
+                                                    <port>8090:8090</port>
+                                                </ports>
+                                                <wait>
+                                                    <http>
+                                                        <url>http://localhost:8090/transform/config</url>
+                                                        <method>GET</method>
+                                                        <status>200...299</status>
+                                                    </http>
+                                                    <time>300000</time>
+                                                    <kill>500</kill>
+                                                    <shutdown>100</shutdown>
+                                                    <exec>
+                                                        <preStop>kill 1</preStop>
+                                                        <preStop>kill -9 1</preStop>
+                                                    </exec>
+                                                </wait>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>after-integration-tests</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -253,26 +256,25 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>build-image</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${image.name}:${image.tag}</name>
+                                            <build>
+                                                <contextDir>${project.basedir}</contextDir>
+                                                <buildOptions>
+                                                    <squash>true</squash>
+                                                </buildOptions>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -294,7 +296,7 @@
                                     <name>${image.name}:${image.tag}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -304,7 +306,7 @@
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -313,13 +315,6 @@
                             </images>
                         </configuration>
                         <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
                             <execution>
                                 <id>push-image</id>
                                 <phase>install</phase>
@@ -341,13 +336,13 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
-                            <images combine.self="override">
+                            <images>
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <registry>${image.registry}</registry>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -357,7 +352,7 @@
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
+                                        <contextDir>${project.basedir}</contextDir>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -368,7 +363,6 @@
                         <executions>
                             <execution>
                                 <id>build-push-image</id>
-                                <phase>deploy</phase>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -167,7 +167,7 @@
 
     <profiles>
         <profile>
-            <id>    docker-it-setup</id>
+            <id>docker-it-setup</id>
             <!-- raises an ActiveMq container for the Integration Tests -->
             <build>
                 <plugins>
@@ -180,15 +180,14 @@
                         <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>before-integration-tests</id>
+                                <id>integration-tests</id>
                                 <goals>
-                                    <goal>stop</goal>
                                     <goal>start</goal>
+                                    <goal>stop</goal>
                                 </goals>
                                 <configuration>
                                     <images>
                                         <image>
-                                            <alias>activemq</alias>
                                             <name>alfresco/alfresco-activemq:5.16.1</name>
                                             <run>
                                                 <hostname>activemq</hostname>
@@ -209,9 +208,7 @@
                                                 </wait>
                                             </run>
                                         </image>
-
                                         <image>
-                                            <alias>tika</alias>
                                             <name>${image.name}:${image.tag}</name>
                                             <run>
                                                 <ports>
@@ -236,13 +233,6 @@
                                     </images>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>after-integration-tests</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -259,6 +249,7 @@
                         <executions>
                             <execution>
                                 <id>build-image</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -316,9 +307,9 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>push-image</id>
                                 <phase>install</phase>
                                 <goals>
+                                    <goal>build</goal>
                                     <goal>push</goal>
                                 </goals>
                             </execution>
@@ -362,7 +353,6 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>build-push-image</id>
                                 <goals>
                                     <goal>build</goal>
                                     <goal>push</goal>

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -252,7 +252,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <image>
@@ -286,7 +286,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <!-- QuayIO image -->
@@ -339,9 +339,9 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <configuration combine.self="override">
-                            <images>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images combine.self="override">
                                 <!-- QuayIO image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>

--- a/alfresco-transform-tika/alfresco-transform-tika/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/pom.xml
@@ -3,7 +3,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-transform-tika</artifactId>
     <name>Alfresco Tika Transformer</name>
-    <packaging>jar</packaging>
 
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
@@ -117,14 +116,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>

--- a/alfresco-transformer-base/pom.xml
+++ b/alfresco-transformer-base/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -5,7 +6,6 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
         <version>2.5.7-A3-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alfresco-transformer-base</artifactId>
@@ -80,7 +80,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -400,24 +400,6 @@
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>0.39.0</version>
-                    <extensions>true</extensions>
-                    <executions>
-                        <execution>
-                            <id>before-integration-tests</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>stop</goal>
-                                <goal>start</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>after-integration-tests</id>
-                            <phase>post-integration-test</phase>
-                            <goals>
-                                <goal>stop</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                  </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -398,32 +398,9 @@
                 </plugin>
                 <plugin>
                     <groupId>io.fabric8</groupId>
-                    <artifactId>fabric8-maven-plugin</artifactId>
-                    <version>4.4.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>0.39.0</version>
-                    <extensions>true</extensions>
-                    <executions>
-                        <execution>
-                            <id>before-integration-tests</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>stop</goal>
-                                <goal>start</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>after-integration-tests</id>
-                            <phase>post-integration-test</phase>
-                            <goals>
-                                <goal>stop</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
+                 </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,24 @@
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>0.39.0</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <id>before-integration-tests</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                                <goal>stop</goal>
+                                <goal>start</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>after-integration-tests</id>
+                            <phase>post-integration-test</phase>
+                            <goals>
+                                <goal>stop</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                  </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.6.3</version>
+        <relativePath/>
     </parent>
 
     <properties>
@@ -33,7 +34,6 @@
 
         <parent.core.deploy.skip>false</parent.core.deploy.skip>
     </properties>
-
 
     <profiles>
         <profile>
@@ -113,6 +113,7 @@
             </modules>
         </profile>
     </profiles>
+
     <scm>
         <connection>scm:git:https://github.com/Alfresco/alfresco-transform-core.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-transform-core.git</developerConnection>
@@ -264,7 +265,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.1</version>
                 <configuration>
                     <doclint>none</doclint>
                 </configuration>
@@ -290,6 +290,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                     <configuration>
@@ -370,15 +371,6 @@
                             <buildDirectory>${project.build.directory}</buildDirectory>
                         </systemPropertyVariables>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <id>default-test</id>
-                            <goals>
-                                <goal>test</goal>
-                            </goals>
-                            <phase>test</phase>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -387,14 +379,6 @@
                         <forkCount>1</forkCount>
                         <reuseForks>true</reuseForks>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>integration-test</goal>
-                                <goal>verify</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>io.fabric8</groupId>


### PR DESCRIPTION
Replaced fabric8-maven-plugin with docker-maven-plugin and performed pom cleanup:
* moved configurations from the plugin to the execution level to avoid overlap
* removed duplicated execution of spring-boot:repackage

Ref. ATS-864