### PR TITLE
WIP: ATS-968 switch ATS Core java base image to CentOS 7

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
@@ -12,9 +12,7 @@ ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}
 ARG EXIFTOOL_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/exiftool/image-exiftool/${EXIFTOOL_VERSION}/image-exiftool-${EXIFTOOL_VERSION}.tgz
 
 ARG IMAGEMAGICK_VERSION=7.0.10-59
-ENV IMAGEMAGICK_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}/imagemagick-distribution-${IMAGEMAGICK_VERSION}-linux.rpm
-ENV IMAGEMAGICK_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}/imagemagick-distribution-${IMAGEMAGICK_VERSION}-libs-linux.rpm
-ENV IMAGEMAGICK_DEP_RPM_URL=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+ENV IMAGEMAGICK_SRC_URL=https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
 
 ARG LIBREOFFICE_VERSION=7.0.6
 ENV LIBREOFFICE_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/libreoffice/libreoffice-dist/${LIBREOFFICE_VERSION}/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz
@@ -33,12 +31,15 @@ COPY target/alfresco-transform-core-aio-boot-${env.project_version}.jar /usr/bin
 
 RUN ln /usr/bin/alfresco-transform-core-aio-boot-${env.project_version}.jar /usr/bin/alfresco-transform-core-aio-boot.jar && \
     yum clean all && \
-    curl -s -S $IMAGEMAGICK_RPM_URL      -o imagemagick-distribution-linux.rpm && \
-    curl -s -S $IMAGEMAGICK_LIB_RPM_URL  -o imagemagick-distribution-libs-linux.rpm && \
-    curl -s -S $IMAGEMAGICK_DEP_RPM_URL  -o imagemagick-epel-dep.rpm && \
-    yum localinstall -y imagemagick-epel-dep.rpm && \
-    yum localinstall -y imagemagick-distribution-*linux.rpm && \
-    rm -f imagemagick-distribution-*.rpm && \
+    yum -y group install "Development Tools" && \
+    curl -s -S $IMAGEMAGICK_SRC_URL -o ImageMagick-7.0.10-59.tar.xz && \
+    tar -xf ImageMagick-7.0.10-59.tar.xz && \
+    cd ImageMagick-7.0.10-59 && \
+    ./configure && \
+    make && \
+    make install && \
+    ldconfig /usr/local/lib && \
+    cd / && \
     yum install -y cairo cups-libs libSM libGLU && \
     test -f libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz && \
     ln -s libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz libreoffice-dist-linux.gz || \

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
@@ -5,7 +5,7 @@
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.12-centos-811@sha256:f1bb731da820f33dc1e3cfe27d3192b67d68237d0a4441829140dfbd1e48c8a5
+FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865eb25627bb241b11da406ef8df91a77716a3538f36
 
 ARG EXIFTOOL_VERSION=12.25
 ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}
@@ -32,6 +32,7 @@ ARG USERID=33017
 COPY target/alfresco-transform-core-aio-boot-${env.project_version}.jar /usr/bin
 
 RUN ln /usr/bin/alfresco-transform-core-aio-boot-${env.project_version}.jar /usr/bin/alfresco-transform-core-aio-boot.jar && \
+    yum clean all && \
     curl -s -S $IMAGEMAGICK_RPM_URL      -o imagemagick-distribution-linux.rpm && \
     curl -s -S $IMAGEMAGICK_LIB_RPM_URL  -o imagemagick-distribution-libs-linux.rpm && \
     curl -s -S $IMAGEMAGICK_DEP_RPM_URL  -o imagemagick-epel-dep.rpm && \

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/Dockerfile
@@ -52,6 +52,8 @@ RUN ln /usr/bin/alfresco-transform-core-aio-boot-${env.project_version}.jar /usr
     curl -s -S $EXIFTOOL_URL -o ${EXIFTOOL_FOLDER}.tgz && \
     tar xzf ${EXIFTOOL_FOLDER}.tgz && \
     yum -y install perl && \
+    yum -y install perl-ExtUtils-MakeMaker && \
+    yum -y install make && \
     (cd ./${EXIFTOOL_FOLDER} && \
     perl Makefile.PL && \
     make && \

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
@@ -6,9 +6,7 @@ FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865
 
 ARG IMAGEMAGICK_VERSION=7.0.10-59
 
-ENV IMAGEMAGICK_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}/imagemagick-distribution-${IMAGEMAGICK_VERSION}-linux.rpm
-ENV IMAGEMAGICK_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}/imagemagick-distribution-${IMAGEMAGICK_VERSION}-libs-linux.rpm
-ENV IMAGEMAGICK_DEP_RPM_URL=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+ENV IMAGEMAGICK_SRC_URL=https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
 ENV JAVA_OPTS=""
 
 # Set default user information
@@ -21,13 +19,16 @@ COPY target/${env.project_artifactId}-${env.project_version}.jar /usr/bin
 
 RUN ln /usr/bin/${env.project_artifactId}-${env.project_version}.jar /usr/bin/${env.project_artifactId}.jar && \
     yum clean all && \
-    curl -s -S $IMAGEMAGICK_RPM_URL      -o imagemagick-distribution-linux.rpm && \
-    curl -s -S $IMAGEMAGICK_LIB_RPM_URL  -o imagemagick-distribution-libs-linux.rpm && \
-    curl -s -S $IMAGEMAGICK_DEP_RPM_URL  -o imagemagick-epel-dep.rpm && \
-    yum localinstall -y imagemagick-epel-dep.rpm && \
-    yum localinstall -y imagemagick-distribution-*linux.rpm && \
-    rm -f imagemagick-distribution-*.rpm && \
-    yum clean all
+    yum -y group install "Development Tools" && \
+    curl -s -S $IMAGEMAGICK_SRC_URL -o ImageMagick-7.0.10-59.tar.xz && \
+    tar -xf ImageMagick-7.0.10-59.tar.xz && \
+    cd ImageMagick-7.0.10-59 && \
+    ./configure && \
+    make && \
+    make install && \
+    ldconfig /usr/local/lib && \
+    yum clean all && \
+    cd /
 
 ADD target/generated-resources/licenses              /licenses
 ADD target/generated-resources/licenses.xml          /licenses/

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # ImageMagick is from ImageMagick Studio LLC. See the license at http://www.imagemagick.org/script/license.php or in /ImageMagick-license.txt.
 
-FROM alfresco/alfresco-base-java:11.0.12-centos-811@sha256:f1bb731da820f33dc1e3cfe27d3192b67d68237d0a4441829140dfbd1e48c8a5
+FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865eb25627bb241b11da406ef8df91a77716a3538f36
 
 ARG IMAGEMAGICK_VERSION=7.0.10-59
 
@@ -20,6 +20,7 @@ ARG USERID=33002
 COPY target/${env.project_artifactId}-${env.project_version}.jar /usr/bin
 
 RUN ln /usr/bin/${env.project_artifactId}-${env.project_version}.jar /usr/bin/${env.project_artifactId}.jar && \
+    yum clean all && \
     curl -s -S $IMAGEMAGICK_RPM_URL      -o imagemagick-distribution-linux.rpm && \
     curl -s -S $IMAGEMAGICK_LIB_RPM_URL  -o imagemagick-distribution-libs-linux.rpm && \
     curl -s -S $IMAGEMAGICK_DEP_RPM_URL  -o imagemagick-epel-dep.rpm && \

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/Dockerfile
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # LibreOffice is from The Document Foundation. See the license at https://www.libreoffice.org/download/license/ or in /libreoffice.txt.
 
-FROM alfresco/alfresco-base-java:11.0.12-centos-811@sha256:f1bb731da820f33dc1e3cfe27d3192b67d68237d0a4441829140dfbd1e48c8a5
+FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865eb25627bb241b11da406ef8df91a77716a3538f36
 
 ARG LIBREOFFICE_VERSION=7.0.6
 

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/Dockerfile
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/Dockerfile
@@ -1,6 +1,6 @@
 # Image provides a container in which to run miscellaneous transformations for Alfresco Content Services.
 
-FROM alfresco/alfresco-base-java:11.0.12-centos-811@sha256:f1bb731da820f33dc1e3cfe27d3192b67d68237d0a4441829140dfbd1e48c8a5
+FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865eb25627bb241b11da406ef8df91a77716a3538f36
 
 ENV JAVA_OPTS=""
 

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/Dockerfile
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # alfresco-pdf-renderer uses the PDFium library from Google Inc. See the license at https://pdfium.googlesource.com/pdfium/+/master/LICENSE or in /pdfium.txt.
 
-FROM alfresco/alfresco-base-java:11.0.12-centos-811@sha256:f1bb731da820f33dc1e3cfe27d3192b67d68237d0a4441829140dfbd1e48c8a5
+FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865eb25627bb241b11da406ef8df91a77716a3538f36
 
 ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/1.1/alfresco-pdf-renderer-1.1-linux.tgz
 ENV JAVA_OPTS=""

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tika is from Apache. See the license at http://www.apache.org/licenses/LICENSE-2.0.
 
-FROM alfresco/alfresco-base-java:11.0.12-centos-811@sha256:f1bb731da820f33dc1e3cfe27d3192b67d68237d0a4441829140dfbd1e48c8a5
+FROM alfresco/alfresco-base-java:11.0.12-centos-7@sha256:6abdbfd14492fb78ae5d865eb25627bb241b11da406ef8df91a77716a3538f36
 
 ARG EXIFTOOL_VERSION=12.25
 ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile
@@ -22,6 +22,8 @@ RUN ln /usr/bin/${env.project_artifactId}-${env.project_version}.jar /usr/bin/${
     curl -s -S $EXIFTOOL_URL -o ${EXIFTOOL_FOLDER}.tgz && \
     tar xzf ${EXIFTOOL_FOLDER}.tgz && \
     yum -y install perl && \
+    yum -y install perl-ExtUtils-MakeMaker && \
+    yum -y install make && \
     (cd ./${EXIFTOOL_FOLDER} && \
     perl Makefile.PL && \
     make && \


### PR DESCRIPTION
ImageMagick is built from source to maintain the same version as used with CentOS 8.  
Project builds without errors but wasn't yet tested for regression.  
Still needs replacing ImageMagick download page with Nexus one.