### PR TITLE
ATS-970: Fix build after Travis secrets rotation

### DIFF
--- a/_ci/init.sh
+++ b/_ci/init.sh
@@ -6,7 +6,7 @@ set -vex
 pushd "$(dirname "${BASH_SOURCE[0]}")/../"
 
 mkdir -p ${HOME}/.m2 && cp -rf _ci/settings.xml ${HOME}/.m2/
-echo "${QUAY_PASSWORD}" | docker login -u="alfresco+bamboo" --password-stdin quay.io
+echo "${QUAY_PASSWORD}" | docker login -u="${QUAY_USERNAME}" --password-stdin quay.io
 echo "${DOCKERHUB_PASSWORD}" | docker login -u=${DOCKERHUB_USERNAME} --password-stdin docker.io
 find "${HOME}/.m2/repository/" -type d -name "*-SNAPSHOT*" | xargs -r -l rm -rf
 

--- a/_ci/settings.xml
+++ b/_ci/settings.xml
@@ -39,50 +39,50 @@
         <!-- Credential for private Nexus repository groups -->
         <server>
             <id>alfresco-internal</id>
-            <username>bamboo</username>
+            <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <!-- Credential for private Nexus repositories -->
         <server>
             <id>alfresco-internal-snapshots</id>
-            <username>bamboo</username>
+            <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
             <id>alfresco-internal-releases</id>
-            <username>bamboo</username>
+            <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
             <id>alfresco-enterprise-snapshots</id>
-            <username>bamboo</username>
+            <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
             <id>alfresco-enterprise-releases</id>
-            <username>bamboo</username>
+            <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
             <id>alfresco-public-snapshots</id>
-            <username>bamboo</username>
+            <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
             <id>alfresco-public</id>
-            <username>bamboo</username>
+            <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
             <id>alfresco-thirdparty</id>
-            <username>bamboo</username>
+            <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
 
         <!-- private docker registry-->
         <server>
             <id>quay.io</id>
-            <username>alfresco+bamboo</username>
+            <username>${env.QUAY_USERNAME}</username>
             <password>${env.QUAY_PASSWORD}</password>
         </server>
         <server>


### PR DESCRIPTION
- use QUAY_USERNAME  (set to "alfresco+travis_ci")
- (instead of old hard-coded "alfresco+bamboo" robot account that no longer exists)
- update settings.xml to use env vars for usernames (consistent with other projects)