### PR TITLE
ACS-2003 Tika transformers will not create temporary files on disk

### DIFF
--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,17 +26,23 @@
  */
 package org.alfresco.transformer;
 
+import org.alfresco.transform.client.registry.TransformServiceRegistry;
 import org.alfresco.transformer.executors.ImageMagickCommandExecutor;
 import org.alfresco.transformer.probes.ProbeTestTransform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
+
+import static org.alfresco.transformer.fs.FileManager.createSourceFile;
+import static org.alfresco.transformer.fs.FileManager.deleteFile;
 
 /**
  * Controller for the Docker based ImageMagick transformer.
@@ -116,16 +122,35 @@ public class  ImageMagickController extends AbstractTransformerController
     }
 
     @Override
-    protected String getTransformerName(final File sourceFile, final String sourceMimetype,
-                                        final String targetMimetype, final Map<String, String> transformOptions)
-    {
-        return null; // does not matter what value is returned, as it is not used because there is only one.
-    }
-
-    @Override
     public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
                                  Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }
+
+    @Override
+    public void transformImpl(TransformServiceRegistry transformServiceRegistry, String requestTransformName,
+                              String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
+                              HttpServletRequest request, MultipartFile sourceMultipartFile, File targetFile)
+    {
+        File tempSourceFile = null;
+        try
+        {
+            tempSourceFile = createSourceFile(request, sourceMultipartFile);
+            transformImpl(null, sourceMimetype, targetMimetype, transformOptions, tempSourceFile, targetFile);
+        } finally
+        {
+            try
+            {
+                if (tempSourceFile != null)
+                {
+                    deleteFile(tempSourceFile);
+                }
+            } catch (Exception e)
+            {
+                logger.error("Failed to delete source local temp file " + tempSourceFile, e);
+            }
+        }
+    }
+
 }

--- a/alfresco-transform-misc/alfresco-transform-misc/src/main/java/org/alfresco/transformer/metadataExtractors/RFC822MetadataExtractor.java
+++ b/alfresco-transform-misc/alfresco-transform-misc/src/main/java/org/alfresco/transformer/metadataExtractors/RFC822MetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005-2020 Alfresco Software Limited
+ * Copyright (C) 2005-2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -90,14 +90,21 @@ public class RFC822MetadataExtractor extends AbstractMetadataExtractor implement
     }
 
     @Override
+    public Map<String, Serializable> extractMetadata(String sourceMimetype, Map<String, String> transformOptions, File sourceFile) throws Exception
+    {
+        try (InputStream inputStream = new FileInputStream(sourceFile))
+        {
+            return extractMetadata(sourceMimetype, transformOptions, inputStream);
+        }
+    }
+
+    @Override
     public Map<String, Serializable> extractMetadata(String sourceMimetype, Map<String, String> transformOptions,
-                                                     File sourceFile) throws Exception
+                                                     InputStream inputStream) throws Exception
     {
         final Map<String, Serializable> rawProperties = new HashMap<>();
 
-        try (InputStream is = new FileInputStream(sourceFile))
-        {
-            MimeMessage mimeMessage = new MimeMessage(null, is);
+            MimeMessage mimeMessage = new MimeMessage(null, inputStream);
 
             if (mimeMessage != null)
             {
@@ -188,8 +195,6 @@ public class RFC822MetadataExtractor extends AbstractMetadataExtractor implement
                     }
                 }
             }
-        }
-
         return rawProperties;
     }
 }

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,17 +26,23 @@
  */
 package org.alfresco.transformer;
 
+import org.alfresco.transform.client.registry.TransformServiceRegistry;
 import org.alfresco.transformer.executors.PdfRendererCommandExecutor;
 import org.alfresco.transformer.probes.ProbeTestTransform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
+
+import static org.alfresco.transformer.fs.FileManager.createSourceFile;
+import static org.alfresco.transformer.fs.FileManager.deleteFile;
 
 /**
  * Controller for the Docker based alfresco-pdf-renderer transformer.
@@ -103,16 +109,35 @@ public class AlfrescoPdfRendererController extends AbstractTransformerController
     }
 
     @Override
-    protected String getTransformerName(final File sourceFile, final String sourceMimetype,
-                                        final String targetMimetype, final Map<String, String> transformOptions)
-    {
-        return null; // does not matter what value is returned, as it is not used because there is only one.
-    }
-
-    @Override
     public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
                                  Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
         commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }
+
+    @Override
+    public void transformImpl(TransformServiceRegistry transformServiceRegistry, String requestTransformName,
+                              String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
+                              HttpServletRequest request, MultipartFile sourceMultipartFile, File targetFile)
+    {
+        File tempSourceFile = null;
+        try
+        {
+            tempSourceFile = createSourceFile(request, sourceMultipartFile);
+            transformImpl(null, sourceMimetype, targetMimetype, transformOptions, tempSourceFile, targetFile);
+        } finally
+        {
+            try
+            {
+                if (tempSourceFile != null)
+                {
+                    deleteFile(tempSourceFile);
+                }
+            } catch (Exception e)
+            {
+                logger.error("Failed to delete source local temp file " + tempSourceFile, e);
+            }
+        }
+    }
+
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
@@ -288,6 +288,15 @@ public class TikaControllerTest extends AbstractTransformerControllerTest
     }
 
     @Test
+    public void testAbleToTransformFileForBackwardsCompatibility()
+    {
+        ProbeTestTransform probeTestTransform = getController().getProbeTestTransform();
+        ReflectionTestUtils.setField(probeTestTransform, "livenessTransformEnabled", true);
+        probeTestTransform.setUseTempSourceFile(true);
+        probeTestTransform.doTransformOrNothing(httpServletRequest, true);
+    }
+
+    @Test
     @Override
     public void simpleTransformTest() throws Exception
     {

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/fs/FileManager.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/fs/FileManager.java
@@ -44,6 +44,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.alfresco.transform.exceptions.TransformException;
 import org.alfresco.transformer.logging.LogEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.http.HttpHeaders;
@@ -56,6 +58,7 @@ import org.springframework.web.util.UriUtils;
  */
 public class FileManager
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileManager.class);
     public static final String SOURCE_FILE = "sourceFile";
     public static final String TARGET_FILE = "targetFile";
     private static final String FILENAME = "filename=";
@@ -220,6 +223,7 @@ public class FileManager
         request.setAttribute(SOURCE_FILE, file);
         save(multipartFile, file);
         LogEntry.setSource(filename, size);
+        LOGGER.info("Temporary source file created: " + file.getAbsolutePath());
         return file;
     }
 

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/util/TransformerNameUtil.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/util/TransformerNameUtil.java
@@ -1,0 +1,90 @@
+/*
+ * #%L
+ * Alfresco Transform Core
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * -
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ * -
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * -
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * -
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.transformer.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alfresco.transform.client.registry.TransformServiceRegistry;
+import org.alfresco.transform.exceptions.TransformException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.alfresco.transformer.util.RequestParamMap.SOURCE_ENCODING;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+
+public class TransformerNameUtil
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransformerNameUtil.class);
+
+    public static String getTransformerName(TransformServiceRegistry transformRegistry, String sourceMimetype, long sourceSizeInBytes,
+                                            String targetMimetype, String requestTransformName, Map<String, String> transformOptions)
+    {
+        if (transformNameWasProvidedInTheRequest(requestTransformName))
+        {
+            if (LOGGER.isInfoEnabled())
+            {
+                LOGGER.info("Using transform name provided in the request: " + requestTransformName);
+            }
+            return requestTransformName;
+        }
+        return getTransformerName(transformRegistry, sourceMimetype, sourceSizeInBytes, targetMimetype, transformOptions);
+    }
+
+    public static String getTransformerName(TransformServiceRegistry transformRegistry, String sourceMimetype, long sourceSizeInBytes,
+                                            String targetMimetype, Map<String, String> transformOptions)
+    {
+        String transformerName = transformRegistry.findTransformerName(sourceMimetype, sourceSizeInBytes, targetMimetype,
+                                                                       getOptionsWithoutEncoding(transformOptions), null);
+        if (transformerName == null)
+        {
+            throw new TransformException(BAD_REQUEST.value(), "No transforms were able to handle the request");
+        }
+        return transformerName;
+    }
+
+    /**
+     * Might happen for ACS legacy transformers
+     */
+    private static boolean transformNameWasProvidedInTheRequest(String requestTransformName)
+    {
+        return requestTransformName != null && !requestTransformName.isBlank();
+    }
+
+    /**
+     * Source encoding should not be used to select a transformer
+     */
+    private static Map<String, String> getOptionsWithoutEncoding(Map<String, String> transformOptions)
+    {
+        Map<String, String> safeOptions = new HashMap<>(transformOptions);
+        safeOptions.remove(SOURCE_ENCODING);
+        return safeOptions;
+    }
+
+}
+

--- a/alfresco-transformer-base/src/test/java/org/alfresco/transformer/util/TransformerNameUtilTest.java
+++ b/alfresco-transformer-base/src/test/java/org/alfresco/transformer/util/TransformerNameUtilTest.java
@@ -1,0 +1,118 @@
+/*
+ * #%L
+ * Alfresco Transform Core
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * -
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ * -
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * -
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * -
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.transformer.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alfresco.transform.client.registry.TransformServiceRegistry;
+import org.alfresco.transform.exceptions.TransformException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.alfresco.transformer.util.RequestParamMap.SOURCE_ENCODING;
+import static org.alfresco.transformer.util.TransformerNameUtil.getTransformerName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+
+class TransformerNameUtilTest
+{
+    private static final long FILESIZE = 100L;
+    private static final String SOURCE_MIMETYPE = "SOURCE_MIME_TYPE";
+    private static final String TARGET_MIMETYPE = "TARGET_MIME_TYPE";
+    private static final String REQUEST_TRANSFORM_NAME = "REQUEST_TRANSFORM_NAME";
+    private static final String REGISTRY_TRANSFORM_NAME = "REGISTRY_TRANSFORM_NAME";
+    private static final String ENCODING = "ENCODING";
+    private static final String TRANSFORM_OPTION = "TRANSFORM_OPTION";
+    private Map<String, String> transformOptions = new HashMap<>();
+    @Mock
+    private TransformServiceRegistry registryMock;
+    @Captor
+    private ArgumentCaptor<Map<String, String>> captorMap;
+
+    @BeforeEach
+    public void setUp()
+    {
+        MockitoAnnotations.openMocks(this);
+        transformOptions.put(SOURCE_ENCODING, ENCODING);
+        transformOptions.put(TRANSFORM_OPTION, TRANSFORM_OPTION);
+        when(registryMock.findTransformerName(eq(SOURCE_MIMETYPE), eq(FILESIZE), eq(TARGET_MIMETYPE), anyMap(), isNull())).thenReturn(REGISTRY_TRANSFORM_NAME);
+    }
+
+    @Test
+    public void returnsProvidedTransformName()
+    {
+        assertThat(getTransformerName(registryMock, SOURCE_MIMETYPE, FILESIZE, TARGET_MIMETYPE, REQUEST_TRANSFORM_NAME, transformOptions),
+                   is(REQUEST_TRANSFORM_NAME));
+    }
+
+    @Test
+    public void usesRegistryOnNullTransformNameParameter()
+    {
+        assertThat(getTransformerName(registryMock, SOURCE_MIMETYPE, FILESIZE, TARGET_MIMETYPE, null, transformOptions),
+                   is(REGISTRY_TRANSFORM_NAME));
+    }
+
+    @Test
+    public void usesRegistryOnBlankTransformNameParameter()
+    {
+        assertThat(getTransformerName(registryMock, SOURCE_MIMETYPE, FILESIZE, TARGET_MIMETYPE, "", transformOptions),
+                   is(REGISTRY_TRANSFORM_NAME));
+    }
+
+    @Test
+    public void throwsExceptionWhenCantFindTransformer()
+    {
+        when(registryMock.findTransformerName(eq(SOURCE_MIMETYPE), eq(FILESIZE), eq(TARGET_MIMETYPE), anyMap(), isNull())).thenReturn(null);
+        TransformException transformException = assertThrows(TransformException.class,
+                                                             () -> getTransformerName(registryMock, SOURCE_MIMETYPE, FILESIZE, TARGET_MIMETYPE, null, transformOptions));
+        assertThat(transformException.getStatusCode(), is(BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void passesOptionsWithoutEncoding()
+    {
+        getTransformerName(registryMock, SOURCE_MIMETYPE, FILESIZE, TARGET_MIMETYPE, null, transformOptions);
+        verify(registryMock).findTransformerName(eq(SOURCE_MIMETYPE), eq(FILESIZE), eq(TARGET_MIMETYPE), captorMap.capture(), isNull());
+        assertThat(captorMap.getValue().size(), is(1));
+        assertThat(captorMap.getValue().get(SOURCE_ENCODING), is(nullValue()));
+    }
+
+}


### PR DESCRIPTION
Source file will not be created anymore for Tika transformer.

All changes are backwards compatible for all transformers.
All APIs which used temp file on disk is workable (Tika including).
Old processing path is workable and callable in Tika too (see TikaController for example).
Similar work can be done for Misc transformers.

Probe Test in Tika  transformers now is configurable and can use old temp file on disk path or not.