### PR TITLE
ATS-969 Tika upgrade 1.x -> 2.x

### DIFF
--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -65,13 +65,9 @@
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
+            <artifactId>tika-parsers-standard-package</artifactId>
             <version>${dependency.tika.version}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>com.tdunning</groupId>
-                    <artifactId>json</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
@@ -80,12 +76,18 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcmail-jdk15on</artifactId>
                 </exclusion>
-                <!-- TODO ATS-534 check transformations not affected by this missing quartz lib -->
                 <exclusion>
-                    <groupId>org.quartz-scheduler</groupId>
-                    <artifactId>quartz</artifactId>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- Needed for correct date/time formats -->
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.2</version>
         </dependency>
 
         <!-- for Apache Tika Parsers - eg. encrypted PDF -->

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.3g2_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.3g2_metadata.json
@@ -2,7 +2,8 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "1000",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "8000",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null
+  "{http://www.alfresco.org/model/content/1.0}title" : null,
+  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Stereo"
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.3gp_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.3gp_metadata.json
@@ -2,7 +2,8 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "1000",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "8000",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null
+  "{http://www.alfresco.org/model/content/1.0}title" : null,
+  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Stereo"
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.m4v_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.m4v_metadata.json
@@ -2,7 +2,8 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "1000",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "22050",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null
+  "{http://www.alfresco.org/model/content/1.0}title" : null,
+  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Stereo"
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.mov_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.mov_metadata.json
@@ -2,7 +2,8 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "1000",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "22050",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null
+  "{http://www.alfresco.org/model/content/1.0}title" : null,
+  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Mono"
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.mp4_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.mp4_metadata.json
@@ -2,7 +2,8 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "90000",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "22050",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null
+  "{http://www.alfresco.org/model/content/1.0}title" : null,
+  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Mono"
 }

--- a/alfresco-transform-tika/alfresco-transform-tika/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/pom.xml
@@ -27,13 +27,9 @@
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
+            <artifactId>tika-parsers-standard-package</artifactId>
             <version>${dependency.tika.version}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>com.tdunning</groupId>
-                    <artifactId>json</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
@@ -42,16 +38,18 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcmail-jdk15on</artifactId>
                 </exclusion>
-                <!-- TODO ATS-534 check transformations not affected by this missing quartz lib -->
-                <exclusion>
-                    <groupId>org.quartz-scheduler</groupId>
-                    <artifactId>quartz</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>xml-apis</groupId>
                     <artifactId>xml-apis</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- Needed for correct date/time formats -->
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.2</version>
         </dependency>
 
         <!-- for Apache Tika Parsers - eg. encrypted PDF -->

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
@@ -29,6 +29,7 @@ package org.alfresco.transformer.metadataExtractors;
 import org.apache.tika.embedder.Embedder;
 import org.apache.tika.extractor.DocumentSelector;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.OfficeOpenXMLCore;
 import org.apache.tika.metadata.Property;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
@@ -263,7 +264,7 @@ public abstract class AbstractTikaMetadataExtractor extends AbstractMetadataExtr
 
             // Get the subject and description, despite things not
             //  being nearly as consistent as one might hope
-            String subject = getMetadataValue(metadata, TikaCoreProperties.SUBJECT);
+            String subject = getMetadataValue(metadata, OfficeOpenXMLCore.SUBJECT);
             String description = getMetadataValue(metadata, TikaCoreProperties.DESCRIPTION);
             if(subject != null && description != null)
             {

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
@@ -57,10 +57,8 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -260,7 +258,7 @@ public abstract class AbstractTikaMetadataExtractor extends AbstractMetadataExtr
             //  to work without needing any changes
 
             // The simple ones
-            putRawValue(KEY_AUTHOR, getAuthor(metadata), rawProperties);
+            putRawValue(KEY_AUTHOR, getMetadataValue(metadata, TikaCoreProperties.CREATOR), rawProperties);
             putRawValue(KEY_TITLE, getMetadataValue(metadata, TikaCoreProperties.TITLE), rawProperties);
             putRawValue(KEY_COMMENTS, getMetadataValue(metadata, TikaCoreProperties.COMMENTS), rawProperties);
 
@@ -391,28 +389,11 @@ public abstract class AbstractTikaMetadataExtractor extends AbstractMetadataExtr
         return values.length == 0 ? null : (values.length == 1 ? values[0] : values);
     }
 
-    private Serializable getAuthor(Metadata metadata)
-    {
-        //heuristic to get single author in case of multiple ones - backward compatibility
-        if (!metadata.isMultiValued(TikaCoreProperties.CREATOR))
-        {
-            return metadata.get(TikaCoreProperties.CREATOR);
-        }
-        List<String> authors = Stream.of(metadata.getValues(TikaCoreProperties.CREATOR))
-                                     .filter(Objects::nonNull)
-                                     .map(String::strip)
-                                     .filter(s -> !s.isEmpty())
-                                     .collect(Collectors.toList());
-        Collections.reverse(authors);
-        return authors.stream().findFirst().orElse(null);
-    }
-
     private String getMetadataValue(Metadata metadata, Property key)
     {
         if (metadata.isMultiValued(key))
         {
             String[] parts = metadata.getValues(key);
-
             return Stream.of(parts)
                          .filter(Objects::nonNull)
                          .map(String::strip)

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
@@ -60,7 +60,10 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The parent of all Metadata Extractors which use Apache Tika under the hood. This handles all the
@@ -390,19 +393,12 @@ public abstract class AbstractTikaMetadataExtractor extends AbstractMetadataExtr
         if (metadata.isMultiValued(key))
         {
             String[] parts = metadata.getValues(key);
-
-            // use Set to prevent duplicates
-            Set<String> value = new LinkedHashSet<>(parts.length);
-
-            for (int i = 0; i < parts.length; i++)
-            {
-                value.add(parts[i]);
-            }
-
-            String valueStr = value.toString();
-
-            // remove leading/trailing braces []
-            return valueStr.substring(1, valueStr.length() - 1);
+            return Stream.of(parts)
+                         .filter(Objects::nonNull)
+                         .map(String::strip)
+                         .filter(s -> !s.isEmpty())
+                         .distinct()
+                         .collect(Collectors.joining(", "));
         }
         else
         {

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/AbstractTikaMetadataExtractor.java
@@ -57,8 +57,10 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -258,7 +260,7 @@ public abstract class AbstractTikaMetadataExtractor extends AbstractMetadataExtr
             //  to work without needing any changes
 
             // The simple ones
-            putRawValue(KEY_AUTHOR, getMetadataValue(metadata, TikaCoreProperties.CREATOR), rawProperties);
+            putRawValue(KEY_AUTHOR, getAuthor(metadata), rawProperties);
             putRawValue(KEY_TITLE, getMetadataValue(metadata, TikaCoreProperties.TITLE), rawProperties);
             putRawValue(KEY_COMMENTS, getMetadataValue(metadata, TikaCoreProperties.COMMENTS), rawProperties);
 
@@ -389,11 +391,28 @@ public abstract class AbstractTikaMetadataExtractor extends AbstractMetadataExtr
         return values.length == 0 ? null : (values.length == 1 ? values[0] : values);
     }
 
+    private Serializable getAuthor(Metadata metadata)
+    {
+        //heuristic to get single author in case of multiple ones - backward compatibility
+        if (!metadata.isMultiValued(TikaCoreProperties.CREATOR))
+        {
+            return metadata.get(TikaCoreProperties.CREATOR);
+        }
+        List<String> authors = Stream.of(metadata.getValues(TikaCoreProperties.CREATOR))
+                                     .filter(Objects::nonNull)
+                                     .map(String::strip)
+                                     .filter(s -> !s.isEmpty())
+                                     .collect(Collectors.toList());
+        Collections.reverse(authors);
+        return authors.stream().findFirst().orElse(null);
+    }
+
     private String getMetadataValue(Metadata metadata, Property key)
     {
         if (metadata.isMultiValued(key))
         {
             String[] parts = metadata.getValues(key);
+
             return Stream.of(parts)
                          .filter(Objects::nonNull)
                          .map(String::strip)

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/DWGMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/DWGMetadataExtractor.java
@@ -27,6 +27,7 @@
 package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.dwg.DWGParser;
 import org.slf4j.Logger;
@@ -64,13 +65,12 @@ public class DWGMetadataExtractor extends AbstractTikaMetadataExtractor
         super(logger);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
     {
-        putRawValue(KEY_KEYWORD, metadata.get(Metadata.KEYWORDS), properties);
-        putRawValue(KEY_LAST_AUTHOR, metadata.get(Metadata.LAST_AUTHOR), properties);
+        putRawValue(KEY_KEYWORD, metadata.get(TikaCoreProperties.SUBJECT), properties);
+        putRawValue(KEY_LAST_AUTHOR, metadata.get(TikaCoreProperties.MODIFIED), properties);
         return properties;
     }
 

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/DWGMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/DWGMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MP3MetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MP3MetadataExtractor.java
@@ -27,6 +27,7 @@
 package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.metadata.XMPDM;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.mp3.Mp3Parser;
@@ -86,7 +87,6 @@ public class MP3MetadataExtractor extends TikaAudioMetadataExtractor
         return new Mp3Parser();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
@@ -98,7 +98,7 @@ public class MP3MetadataExtractor extends TikaAudioMetadataExtractor
         // We only need these for people who had pre-existing mapping
         //  properties from before the proper audio model was added
         putRawValue(KEY_ALBUM_TITLE, metadata.get(XMPDM.ALBUM), properties);
-        putRawValue(KEY_SONG_TITLE, metadata.get(Metadata.TITLE), properties);
+        putRawValue(KEY_SONG_TITLE, metadata.get(TikaCoreProperties.TITLE), properties);
         putRawValue(KEY_ARTIST, metadata.get(XMPDM.ARTIST), properties);
         putRawValue(KEY_COMMENT, metadata.get(XMPDM.LOG_COMMENT), properties);
         putRawValue(KEY_TRACK_NUMBER, metadata.get(XMPDM.TRACK_NUMBER), properties);

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MP3MetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MP3MetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MailMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MailMetadataExtractor.java
@@ -26,7 +26,9 @@
  */
 package org.alfresco.transformer.metadataExtractors;
 
+import org.apache.tika.metadata.Message;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.microsoft.OfficeParser;
 import org.slf4j.Logger;
@@ -82,26 +84,25 @@ public class MailMetadataExtractor extends AbstractTikaMetadataExtractor
         return new OfficeParser();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
     {
-        putRawValue(KEY_ORIGINATOR, metadata.get(Metadata.AUTHOR), properties);
-        putRawValue(KEY_SUBJECT, metadata.get(Metadata.TITLE), properties);
-        putRawValue(KEY_DESCRIPTION, metadata.get(Metadata.SUBJECT), properties);
-        putRawValue(KEY_SENT_DATE, metadata.get(Metadata.LAST_SAVED), properties);
+        putRawValue(KEY_ORIGINATOR, metadata.get(TikaCoreProperties.CREATED), properties);
+        putRawValue(KEY_SUBJECT, metadata.get(TikaCoreProperties.TITLE), properties);
+        putRawValue(KEY_DESCRIPTION, metadata.get(TikaCoreProperties.SUBJECT), properties);
+        putRawValue(KEY_SENT_DATE, metadata.get(TikaCoreProperties.MODIFIED), properties);
 
         // Store the TO, but not cc/bcc in the addressee field
-        putRawValue(KEY_ADDRESSEE, metadata.get(Metadata.MESSAGE_TO), properties);
+        putRawValue(KEY_ADDRESSEE, metadata.get(Message.MESSAGE_TO), properties);
 
         // Store each of To, CC and BCC in their own fields
-        putRawValue(KEY_TO_NAMES, metadata.getValues(Metadata.MESSAGE_TO), properties);
-        putRawValue(KEY_CC_NAMES, metadata.getValues(Metadata.MESSAGE_CC), properties);
-        putRawValue(KEY_BCC_NAMES, metadata.getValues(Metadata.MESSAGE_BCC), properties);
+        putRawValue(KEY_TO_NAMES, metadata.getValues(Message.MESSAGE_TO), properties);
+        putRawValue(KEY_CC_NAMES, metadata.getValues(Message.MESSAGE_CC), properties);
+        putRawValue(KEY_BCC_NAMES, metadata.getValues(Message.MESSAGE_BCC), properties);
 
         // But store all email addresses (to/cc/bcc) in the addresses field
-        putRawValue(KEY_ADDRESSEES, metadata.getValues(Metadata.MESSAGE_RECIPIENT_ADDRESS), properties);
+        putRawValue(KEY_ADDRESSEES, metadata.getValues(Message.MESSAGE_RECIPIENT_ADDRESS), properties);
 
         return properties;
     }

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MailMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MailMetadataExtractor.java
@@ -88,7 +88,7 @@ public class MailMetadataExtractor extends AbstractTikaMetadataExtractor
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
     {
-        putRawValue(KEY_ORIGINATOR, metadata.get(TikaCoreProperties.CREATED), properties);
+        putRawValue(KEY_ORIGINATOR, metadata.get(TikaCoreProperties.CREATOR), properties);
         putRawValue(KEY_SUBJECT, metadata.get(TikaCoreProperties.TITLE), properties);
         putRawValue(KEY_DESCRIPTION, metadata.get(TikaCoreProperties.SUBJECT), properties);
         putRawValue(KEY_SENT_DATE, metadata.get(TikaCoreProperties.MODIFIED), properties);

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MailMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MailMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OfficeMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OfficeMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OfficeMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OfficeMetadataExtractor.java
@@ -27,6 +27,8 @@
 package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.Office;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.microsoft.OfficeParser;
 import org.slf4j.Logger;
@@ -40,7 +42,7 @@ import java.util.Map;
  *
  * Configuration:   (see OfficeMetadataExtractor_metadata_extract.properties and tika_engine_config.json)
  *
- * This extracter uses the POI library to extract the following:
+ * This extractor uses the POI library to extract the following:
  * <pre>
  *   <b>author:</b>             --      cm:author
  *   <b>title:</b>              --      cm:title
@@ -91,23 +93,20 @@ public class OfficeMetadataExtractor extends AbstractTikaMetadataExtractor
         return new OfficeParser();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
     {
-        putRawValue(KEY_CREATE_DATETIME, metadata.get(Metadata.CREATION_DATE), properties);
-        putRawValue(KEY_LAST_SAVE_DATETIME, metadata.get(Metadata.LAST_SAVED), properties);
-        putRawValue(KEY_EDIT_TIME, metadata.get(Metadata.EDIT_TIME), properties);
-        putRawValue(KEY_FORMAT, metadata.get(Metadata.FORMAT), properties);
-        putRawValue(KEY_KEYWORDS, metadata.get(Metadata.KEYWORDS), properties);
-        putRawValue(KEY_LAST_AUTHOR, metadata.get(Metadata.LAST_AUTHOR), properties);
-        putRawValue(KEY_LAST_PRINTED, metadata.get(Metadata.LAST_PRINTED), properties);
-//       putRawValue(KEY_OS_VERSION, metadata.get(Metadata.OS_VERSION), properties);
-//       putRawValue(KEY_THUMBNAIL, metadata.get(Metadata.THUMBNAIL), properties);
-        putRawValue(KEY_PAGE_COUNT, metadata.get(Metadata.PAGE_COUNT), properties);
-        putRawValue(KEY_PARAGRAPH_COUNT, metadata.get(Metadata.PARAGRAPH_COUNT), properties);
-        putRawValue(KEY_WORD_COUNT, metadata.get(Metadata.WORD_COUNT), properties);
+        putRawValue(KEY_CREATE_DATETIME, metadata.get(TikaCoreProperties.CREATED), properties);
+        putRawValue(KEY_LAST_SAVE_DATETIME, metadata.get(TikaCoreProperties.MODIFIED), properties);
+        putRawValue(KEY_EDIT_TIME, metadata.get(TikaCoreProperties.MODIFIED), properties);
+        putRawValue(KEY_FORMAT, metadata.get(TikaCoreProperties.FORMAT), properties);
+        putRawValue(KEY_KEYWORDS, metadata.get(TikaCoreProperties.SUBJECT), properties);
+        putRawValue(KEY_LAST_AUTHOR, metadata.get(TikaCoreProperties.MODIFIER), properties);
+        putRawValue(KEY_LAST_PRINTED, metadata.get(TikaCoreProperties.PRINT_DATE), properties);
+        putRawValue(KEY_PAGE_COUNT, metadata.get(Office.PAGE_COUNT), properties);
+        putRawValue(KEY_PARAGRAPH_COUNT, metadata.get(Office.PARAGRAPH_COUNT), properties);
+        putRawValue(KEY_WORD_COUNT, metadata.get(Office.WORD_COUNT), properties);
         return properties;
     }
 }

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OpenDocumentMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OpenDocumentMetadataExtractor.java
@@ -27,6 +27,7 @@
 package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.odf.OpenDocumentParser;
 import org.joda.time.format.DateTimeFormat;
@@ -93,19 +94,18 @@ public class OpenDocumentMetadataExtractor extends AbstractTikaMetadataExtractor
         return new OpenDocumentParser();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String, String> headers)
     {
-        putRawValue(KEY_CREATION_DATE, getDateOrNull(metadata.get(Metadata.CREATION_DATE)), properties);
-        putRawValue(KEY_CREATOR, metadata.get(Metadata.CREATOR), properties);
-        putRawValue(KEY_DATE, getDateOrNull(metadata.get(Metadata.DATE)), properties);
-        putRawValue(KEY_DESCRIPTION, metadata.get(Metadata.DESCRIPTION), properties);
+        putRawValue(KEY_CREATION_DATE, getDateOrNull(metadata.get(TikaCoreProperties.CREATED)), properties);
+        putRawValue(KEY_CREATOR, metadata.get(TikaCoreProperties.CREATOR), properties);
+        putRawValue(KEY_DATE, getDateOrNull(metadata.get(TikaCoreProperties.MODIFIED)), properties);
+        putRawValue(KEY_DESCRIPTION, metadata.get(TikaCoreProperties.DESCRIPTION), properties);
         putRawValue(KEY_GENERATOR, metadata.get("generator"), properties);
         putRawValue(KEY_INITIAL_CREATOR, metadata.get("initial-creator"), properties);
-        putRawValue(KEY_KEYWORD, metadata.get(Metadata.KEYWORDS), properties);
-        putRawValue(KEY_LANGUAGE, metadata.get(Metadata.LANGUAGE), properties);
+        putRawValue(KEY_KEYWORD, metadata.get(TikaCoreProperties.SUBJECT), properties);
+        putRawValue(KEY_LANGUAGE, metadata.get(TikaCoreProperties.LANGUAGE), properties);
 
         // Handle user-defined properties dynamically
         Map<String, Set<String>> mapping = super.getExtractMapping();

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OpenDocumentMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OpenDocumentMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OpenDocumentMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OpenDocumentMetadataExtractor.java
@@ -111,7 +111,7 @@ public class OpenDocumentMetadataExtractor extends AbstractTikaMetadataExtractor
                 return new TeeContentHandler(superHandler, creatorHandler);
             }
         });
-        return new OpenDocumentParser();
+        return parser;
     }
 
     @Override

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/TikaAudioMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/TikaAudioMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/TikaAudioMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/TikaAudioMetadataExtractor.java
@@ -28,6 +28,7 @@ package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.metadata.XMPDM;
 import org.apache.tika.parser.CompositeParser;
 import org.apache.tika.parser.Parser;
@@ -148,13 +149,12 @@ public class TikaAudioMetadataExtractor extends AbstractTikaMetadataExtractor
      * @param metadata     the metadata extracted from the file
      * @return          the description
      */
-    @SuppressWarnings("deprecation")
     private String generateDescription(Metadata metadata)
     {
         StringBuilder result = new StringBuilder();
-        if (metadata.get(Metadata.TITLE) != null)
+        if (metadata.get(TikaCoreProperties.TITLE) != null)
         {
-            result.append(metadata.get(Metadata.TITLE));
+            result.append(metadata.get(TikaCoreProperties.TITLE));
             if (metadata.get(XMPDM.ALBUM) != null)
             {
                 result

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/tika/parsers/ExifToolParser.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/tika/parsers/ExifToolParser.java
@@ -44,9 +44,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.tika.exception.TikaException;
-import org.apache.tika.io.IOUtils;
-import org.apache.tika.io.NullOutputStream;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -57,7 +57,7 @@ import org.apache.tika.parser.external.ExternalParser;
 import org.apache.tika.parser.external.ExternalParsersFactory;
 import org.apache.tika.parser.image.ImageParser;
 import org.apache.tika.parser.image.TiffParser;
-import org.apache.tika.parser.jpeg.JpegParser;
+import org.apache.tika.parser.image.JpegParser;
 import org.apache.tika.sax.XHTMLContentHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -263,7 +263,7 @@ public class ExifToolParser extends ExternalParser {
      * stream of the given process to the given XHTML content handler.
      * The standard output stream is closed once fully processed.
      *
-     * @param process process
+     * @param stream stream
      * @param xhtml XHTML content handler
      * @throws SAXException if the XHTML SAX events could not be handled
      * @throws IOException if an input error occurred
@@ -315,13 +315,13 @@ public class ExifToolParser extends ExternalParser {
      * standard stream of the given process. Potential exceptions
      * are ignored, and the stream is closed once fully processed.
      *
-     * @param process process
+     * @param stream stream
      */
     private void ignoreStream(final InputStream stream) {
         Thread t = new Thread() {
             public void run() {
                 try {
-                    IOUtils.copy(stream, new NullOutputStream());
+                    IOUtils.copy(stream, NullOutputStream.NULL_OUTPUT_STREAM);
                 } catch (IOException e) {
                 } finally {
                     IOUtils.closeQuietly(stream);

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>
         <dependency.junit.version>4.13.2</dependency.junit.version>
         <dependency.cxf.version>3.4.5</dependency.cxf.version>
-        <dependency.tika.version>1.26</dependency.tika.version>
+        <dependency.tika.version>2.1.0</dependency.tika.version>
         <dependency.poi.version>4.1.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
 


### PR DESCRIPTION
### Noticeable changes:
1. Tika 2.x is more accurate in extracting metadata from media containers.
2. Deprecated code (we relied on) has been removed. New replacement has been found.
3. Internal Metadata representation doesn't match Tika 1.x
    * "Bare" properties like (`Creation-Date`, `Edit-Time`, `Last-Modified`, `Last-Save-Date`) are no longer available in favour of Dublin Core properties.
    * Dublin Core properties have been used to fulfil the default Alfresco mappings.
4. There is no single `Creator` property anymore. For backward compatibility the OpenOffice Parser has been extended.
### What about POI?
Tika 2.1.0 still depend on the POI 4.1.2 so we shouldn't upgrade it.