### PR TITLE
Update log4j version to prevent CVE-2021-44228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
 
         <parent.core.deploy.skip>false</parent.core.deploy.skip>
+        <log4j2.version>2.16.0</log4j2.version>
     </properties>
 
 


### PR DESCRIPTION
alfresco-transform-core:2.5.5-SNAPSHOT has for parent spring-boot-starter-parent:2.6.0 (https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-parent/2.6.0/spring-boot-starter-parent-2.6.0.pom) whose own parent is spring-boot-dependencies:2.6.0 (https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.0/spring-boot-dependencies-2.6.0.pom) which, as a dependency, brings in log4j-bom:2.14.1 (https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-bom/2.14.1/log4j-bom-2.14.1.pom) which pulls in the problematic log4j-core:2.14.1.

Upgrading this property would ensure we pull in the latest log4j-core which is no longer vulnerable