### PR TITLE
ACS-2002 Enhance T-Router debug

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/pom.xml
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/test/java/org/alfresco/transformer/ImageMagickControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -51,7 +51,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -380,18 +379,7 @@ public class ImageMagickControllerTest extends AbstractTransformerControllerTest
         File sourceFile = getTestFile("quick." + sourceExtension, true);
         String targetFileRef = UUID.randomUUID().toString();
 
-        // Transformation Request POJO
-        TransformRequest transformRequest = new TransformRequest();
-        transformRequest.setRequestId("1");
-        transformRequest.setSchema(1);
-        transformRequest.setClientData("Alfresco Digital Business Platform");
-        transformRequest.setTransformRequestOptions(new HashMap<>());
-        transformRequest.setSourceReference(sourceFileRef);
-        transformRequest.setSourceExtension(sourceExtension);
-        transformRequest.setSourceMediaType(sourceMimetype);
-        transformRequest.setSourceSize(sourceFile.length());
-        transformRequest.setTargetExtension(targetExtension);
-        transformRequest.setTargetMediaType(targetMimetype);
+        TransformRequest transformRequest = createTransformRequest(sourceFileRef, sourceFile);
 
         // HTTP Request
         HttpHeaders headers = new HttpHeaders();

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick/pom.xml
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/test/java/org/alfresco/transformer/LibreOfficeControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -51,7 +51,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.UUID;
 
 import javax.annotation.PostConstruct;
@@ -228,16 +227,7 @@ public class LibreOfficeControllerTest extends AbstractTransformerControllerTest
         File sourceFile = getTestFile("quick." + sourceExtension, true);
         String targetFileRef = UUID.randomUUID().toString();
 
-        // Transformation Request POJO
-        TransformRequest transformRequest = new TransformRequest();
-        transformRequest.setRequestId("1");
-        transformRequest.setSchema(1);
-        transformRequest.setClientData("Alfresco Digital Business Platform");
-        transformRequest.setTransformRequestOptions(new HashMap<>());
-        transformRequest.setSourceReference(sourceFileRef);
-        transformRequest.setSourceExtension(sourceExtension);
-        transformRequest.setSourceSize(sourceFile.length());
-        transformRequest.setTargetExtension(targetExtension);
+        TransformRequest transformRequest = createTransformRequest(sourceFileRef, sourceFile);
 
         // HTTP Request
         HttpHeaders headers = new HttpHeaders();

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice/pom.xml
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-misc/alfresco-transform-misc/pom.xml
+++ b/alfresco-transform-misc/alfresco-transform-misc/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/test/java/org/alfresco/transformer/AlfrescoPdfRendererControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -51,7 +51,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -292,16 +291,7 @@ public class AlfrescoPdfRendererControllerTest extends AbstractTransformerContro
         File sourceFile = getTestFile("quick." + sourceExtension, true);
         String targetFileRef = UUID.randomUUID().toString();
 
-        // Transformation Request POJO
-        TransformRequest transformRequest = new TransformRequest();
-        transformRequest.setRequestId("1");
-        transformRequest.setSchema(1);
-        transformRequest.setClientData("Alfresco Digital Business Platform");
-        transformRequest.setTransformRequestOptions(new HashMap<>());
-        transformRequest.setSourceReference(sourceFileRef);
-        transformRequest.setSourceExtension(sourceExtension);
-        transformRequest.setSourceSize(sourceFile.length());
-        transformRequest.setTargetExtension(targetExtension);
+        TransformRequest transformRequest = createTransformRequest(sourceFileRef, sourceFile);
 
         // HTTP Request
         HttpHeaders headers = new HttpHeaders();

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer/pom.xml
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/java/org/alfresco/transformer/TikaControllerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -85,7 +85,6 @@ import static org.springframework.util.StringUtils.getFilenameExtension;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -609,17 +608,7 @@ public class TikaControllerTest extends AbstractTransformerControllerTest
         File sourceFile = getTestFile("quick." + sourceExtension, true);
         String targetFileRef = UUID.randomUUID().toString();
 
-        // Transformation Request POJO
-        TransformRequest transformRequest = new TransformRequest();
-        transformRequest.setRequestId("1");
-        transformRequest.setSchema(1);
-        transformRequest.setClientData("Alfresco Digital Business Platform");
-        transformRequest.setTransformRequestOptions(new HashMap<>());
-        transformRequest.setSourceReference(sourceFileRef);
-        transformRequest.setSourceExtension(sourceExtension);
-        transformRequest.setSourceSize(sourceFile.length());
-        transformRequest.setTargetExtension(targetExtension);
-        transformRequest.setSourceMediaType(sourceMimetype);
+        TransformRequest transformRequest = createTransformRequest(sourceFileRef, sourceFile);
 
         // HTTP Request
         HttpHeaders headers = new HttpHeaders();

--- a/alfresco-transform-tika/alfresco-transform-tika/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>alfresco-transform-core</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-transformer-base/pom.xml
+++ b/alfresco-transformer-base/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>2.5.5-SNAPSHOT</version>
+        <version>2.5.5-A1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alfresco-transformer-base</artifactId>
-    <version>2.5.5-SNAPSHOT</version>
+    <version>2.5.5-A1-SNAPSHOT</version>
 
     <properties>
         <transformer.base.deploy.skip>false</transformer.base.deploy.skip>

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -278,6 +278,7 @@ public abstract class AbstractTransformerController implements TransformControll
             String targetMimetype = request.getTargetMediaType();
             String sourceMimetype = request.getSourceMediaType();
             Map<String, String> transformOptions = request.getTransformRequestOptions();
+            transformerDebug.logOptions(request);
             String transformName = getTransformerName(sourceFile, sourceMimetype, targetMimetype, transformOptions);
             transformImpl(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
         }

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/QueueTransformService.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/QueueTransformService.java
@@ -106,7 +106,7 @@ public class QueueTransformService
             return;
         }
 
-        logger.debug("New T-Request from queue with correlationId: {}", correlationId);
+        logger.trace("New T-Request from queue with correlationId: {}", correlationId);
 
         Optional<TransformRequest> transformRequest;
         try

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/QueueTransformService.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/QueueTransformService.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -106,7 +106,7 @@ public class QueueTransformService
             return;
         }
 
-        logger.info("New T-Request from queue with correlationId: {}", correlationId);
+        logger.debug("New T-Request from queue with correlationId: {}", correlationId);
 
         Optional<TransformRequest> transformRequest;
         try

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/config/WebApplicationConfig.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/config/WebApplicationConfig.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -83,6 +83,6 @@ public class WebApplicationConfig implements WebMvcConfigurer
     @Bean
     public TransformerDebug transformerDebug()
     {
-        return new TransformerDebug();
+        return new TransformerDebug().setIsTEngine(true);
     }
 }

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/config/WebApplicationConfig.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/config/WebApplicationConfig.java
@@ -28,6 +28,7 @@ package org.alfresco.transformer.config;
 
 import org.alfresco.transform.client.model.TransformRequestValidator;
 import org.alfresco.transform.client.registry.TransformServiceRegistry;
+import org.alfresco.transform.router.TransformerDebug;
 import org.alfresco.transformer.TransformInterceptor;
 import org.alfresco.transformer.TransformRegistryImpl;
 import org.alfresco.transformer.clients.AlfrescoSharedFileStoreClient;
@@ -77,5 +78,11 @@ public class WebApplicationConfig implements WebMvcConfigurer
     public TransformServiceRegistry transformRegistry()
     {
         return new TransformRegistryImpl();
+    }
+
+    @Bean
+    public TransformerDebug transformerDebug()
+    {
+        return new TransformerDebug();
     }
 }

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/TransformReplySender.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/TransformReplySender.java
@@ -66,7 +66,7 @@ public class TransformReplySender
                 m.setJMSCorrelationID(correlationId);
                 return m;
             });
-            logger.info("Sent: {} - with correlation ID {}", reply, correlationId);
+            logger.trace("Sent: {} - with correlation ID {}", reply, correlationId);
         }
         catch (Exception e)
         {

--- a/alfresco-transformer-base/src/main/resources/application.yaml
+++ b/alfresco-transformer-base/src/main/resources/application.yaml
@@ -31,6 +31,7 @@ logging:
     org.alfresco.transformer.ImageMagickController: debug
     org.alfresco.transformer.TikaController: debug
     org.alfresco.transformer.MiscellaneousTransformersController: debug
+    org.alfresco.transform.router.TransformerDebug: debug
 
 fileStoreUrl: ${FILE_STORE_URL:http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file}
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-transform-core</artifactId>
-    <version>2.5.5-SNAPSHOT</version>
+    <version>2.5.5-A1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -21,7 +21,7 @@
         <dependency.pdfbox.version>2.0.24</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.12</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
-        <dependency.alfresco-transform-model.version>1.4.5-SNAPSHOT</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.4.5</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.16.3</dependency.activemq.version>
         <dependency.jackson.version>2.13.0</dependency.jackson.version>
         <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency.pdfbox.version>2.0.24</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.12</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
-        <dependency.alfresco-transform-model.version>1.4.4</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.4.5-SNAPSHOT</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.16.3</dependency.activemq.version>
         <dependency.jackson.version>2.13.0</dependency.jackson.version>
         <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency.pdfbox.version>2.0.24</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.12</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
-        <dependency.alfresco-transform-model.version>1.4.3</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.4.4-SNAPSHOT</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.16.3</dependency.activemq.version>
         <dependency.jackson.version>2.13.0</dependency.jackson.version>
         <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency.pdfbox.version>2.0.24</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.12</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
-        <dependency.alfresco-transform-model.version>1.4.4-SNAPSHOT</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.4.4</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.16.3</dependency.activemq.version>
         <dependency.jackson.version>2.13.0</dependency.jackson.version>
         <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>


### PR DESCRIPTION
By default T-Engines now only provide TransformerDebug DEBUG messages, rather than the original detailed request and reply messages, which are still available as TRACE.