### PR TITLE
[trigger release] 2.5.5-A1

### DIFF
--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -65,9 +65,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers-standard-package</artifactId>
+            <artifactId>tika-parsers</artifactId>
             <version>${dependency.tika.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>com.tdunning</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
@@ -76,9 +80,10 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcmail-jdk15on</artifactId>
                 </exclusion>
+                <!-- TODO ATS-534 check transformations not affected by this missing quartz lib -->
                 <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
+                    <groupId>org.quartz-scheduler</groupId>
+                    <artifactId>quartz</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.3g2_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.3g2_metadata.json
@@ -2,8 +2,7 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "8000",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "1000",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null,
-  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Stereo"
+  "{http://www.alfresco.org/model/content/1.0}title" : null
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.3gp_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.3gp_metadata.json
@@ -2,8 +2,7 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "8000",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "1000",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null,
-  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Stereo"
+  "{http://www.alfresco.org/model/content/1.0}title" : null
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.m4v_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.m4v_metadata.json
@@ -2,8 +2,7 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "22050",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "1000",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null,
-  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Stereo"
+  "{http://www.alfresco.org/model/content/1.0}title" : null
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.mov_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.mov_metadata.json
@@ -2,8 +2,7 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "22050",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "1000",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null,
-  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Mono"
+  "{http://www.alfresco.org/model/content/1.0}title" : null
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.mp4_metadata.json
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/test/resources/quick.mp4_metadata.json
@@ -2,8 +2,7 @@
   "{http://www.alfresco.org/model/content/1.0}description" : null,
   "{http://www.alfresco.org/model/audio/1.0}releaseDate" : null,
   "{http://www.alfresco.org/model/content/1.0}created" : null,
-  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "22050",
+  "{http://www.alfresco.org/model/audio/1.0}sampleRate" : "90000",
   "{http://www.alfresco.org/model/content/1.0}author" : null,
-  "{http://www.alfresco.org/model/content/1.0}title" : null,
-  "{http://www.alfresco.org/model/audio/1.0}channelType" : "Mono"
+  "{http://www.alfresco.org/model/content/1.0}title" : null
 }

--- a/alfresco-transform-tika/alfresco-transform-tika/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika/pom.xml
@@ -27,9 +27,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers-standard-package</artifactId>
+            <artifactId>tika-parsers</artifactId>
             <version>${dependency.tika.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>com.tdunning</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
@@ -37,6 +41,11 @@
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcmail-jdk15on</artifactId>
+                </exclusion>
+                <!-- TODO ATS-534 check transformations not affected by this missing quartz lib -->
+                <exclusion>
+                    <groupId>org.quartz-scheduler</groupId>
+                    <artifactId>quartz</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>xml-apis</groupId>

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/DWGMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/DWGMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -27,7 +27,6 @@
 package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.dwg.DWGParser;
 import org.slf4j.Logger;
@@ -65,12 +64,13 @@ public class DWGMetadataExtractor extends AbstractTikaMetadataExtractor
         super(logger);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
     {
-        putRawValue(KEY_KEYWORD, metadata.get(TikaCoreProperties.SUBJECT), properties);
-        putRawValue(KEY_LAST_AUTHOR, metadata.get(TikaCoreProperties.MODIFIED), properties);
+        putRawValue(KEY_KEYWORD, metadata.get(Metadata.KEYWORDS), properties);
+        putRawValue(KEY_LAST_AUTHOR, metadata.get(Metadata.LAST_AUTHOR), properties);
         return properties;
     }
 

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MP3MetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MP3MetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -27,7 +27,6 @@
 package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.metadata.XMPDM;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.mp3.Mp3Parser;
@@ -87,6 +86,7 @@ public class MP3MetadataExtractor extends TikaAudioMetadataExtractor
         return new Mp3Parser();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
@@ -98,7 +98,7 @@ public class MP3MetadataExtractor extends TikaAudioMetadataExtractor
         // We only need these for people who had pre-existing mapping
         //  properties from before the proper audio model was added
         putRawValue(KEY_ALBUM_TITLE, metadata.get(XMPDM.ALBUM), properties);
-        putRawValue(KEY_SONG_TITLE, metadata.get(TikaCoreProperties.TITLE), properties);
+        putRawValue(KEY_SONG_TITLE, metadata.get(Metadata.TITLE), properties);
         putRawValue(KEY_ARTIST, metadata.get(XMPDM.ARTIST), properties);
         putRawValue(KEY_COMMENT, metadata.get(XMPDM.LOG_COMMENT), properties);
         putRawValue(KEY_TRACK_NUMBER, metadata.get(XMPDM.TRACK_NUMBER), properties);

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MailMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/MailMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -26,9 +26,7 @@
  */
 package org.alfresco.transformer.metadataExtractors;
 
-import org.apache.tika.metadata.Message;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.microsoft.OfficeParser;
 import org.slf4j.Logger;
@@ -84,25 +82,26 @@ public class MailMetadataExtractor extends AbstractTikaMetadataExtractor
         return new OfficeParser();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
     {
-        putRawValue(KEY_ORIGINATOR, metadata.get(TikaCoreProperties.CREATOR), properties);
-        putRawValue(KEY_SUBJECT, metadata.get(TikaCoreProperties.TITLE), properties);
-        putRawValue(KEY_DESCRIPTION, metadata.get(TikaCoreProperties.SUBJECT), properties);
-        putRawValue(KEY_SENT_DATE, metadata.get(TikaCoreProperties.MODIFIED), properties);
+        putRawValue(KEY_ORIGINATOR, metadata.get(Metadata.AUTHOR), properties);
+        putRawValue(KEY_SUBJECT, metadata.get(Metadata.TITLE), properties);
+        putRawValue(KEY_DESCRIPTION, metadata.get(Metadata.SUBJECT), properties);
+        putRawValue(KEY_SENT_DATE, metadata.get(Metadata.LAST_SAVED), properties);
 
         // Store the TO, but not cc/bcc in the addressee field
-        putRawValue(KEY_ADDRESSEE, metadata.get(Message.MESSAGE_TO), properties);
+        putRawValue(KEY_ADDRESSEE, metadata.get(Metadata.MESSAGE_TO), properties);
 
         // Store each of To, CC and BCC in their own fields
-        putRawValue(KEY_TO_NAMES, metadata.getValues(Message.MESSAGE_TO), properties);
-        putRawValue(KEY_CC_NAMES, metadata.getValues(Message.MESSAGE_CC), properties);
-        putRawValue(KEY_BCC_NAMES, metadata.getValues(Message.MESSAGE_BCC), properties);
+        putRawValue(KEY_TO_NAMES, metadata.getValues(Metadata.MESSAGE_TO), properties);
+        putRawValue(KEY_CC_NAMES, metadata.getValues(Metadata.MESSAGE_CC), properties);
+        putRawValue(KEY_BCC_NAMES, metadata.getValues(Metadata.MESSAGE_BCC), properties);
 
         // But store all email addresses (to/cc/bcc) in the addresses field
-        putRawValue(KEY_ADDRESSEES, metadata.getValues(Message.MESSAGE_RECIPIENT_ADDRESS), properties);
+        putRawValue(KEY_ADDRESSEES, metadata.getValues(Metadata.MESSAGE_RECIPIENT_ADDRESS), properties);
 
         return properties;
     }

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OfficeMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/OfficeMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -27,8 +27,6 @@
 package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.Office;
-import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.microsoft.OfficeParser;
 import org.slf4j.Logger;
@@ -42,7 +40,7 @@ import java.util.Map;
  *
  * Configuration:   (see OfficeMetadataExtractor_metadata_extract.properties and tika_engine_config.json)
  *
- * This extractor uses the POI library to extract the following:
+ * This extracter uses the POI library to extract the following:
  * <pre>
  *   <b>author:</b>             --      cm:author
  *   <b>title:</b>              --      cm:title
@@ -93,20 +91,23 @@ public class OfficeMetadataExtractor extends AbstractTikaMetadataExtractor
         return new OfficeParser();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
                                                         Map<String, Serializable> properties, Map<String,String> headers)
     {
-        putRawValue(KEY_CREATE_DATETIME, metadata.get(TikaCoreProperties.CREATED), properties);
-        putRawValue(KEY_LAST_SAVE_DATETIME, metadata.get(TikaCoreProperties.MODIFIED), properties);
-        putRawValue(KEY_EDIT_TIME, metadata.get(TikaCoreProperties.MODIFIED), properties);
-        putRawValue(KEY_FORMAT, metadata.get(TikaCoreProperties.FORMAT), properties);
-        putRawValue(KEY_KEYWORDS, metadata.get(TikaCoreProperties.SUBJECT), properties);
-        putRawValue(KEY_LAST_AUTHOR, metadata.get(TikaCoreProperties.MODIFIER), properties);
-        putRawValue(KEY_LAST_PRINTED, metadata.get(TikaCoreProperties.PRINT_DATE), properties);
-        putRawValue(KEY_PAGE_COUNT, metadata.get(Office.PAGE_COUNT), properties);
-        putRawValue(KEY_PARAGRAPH_COUNT, metadata.get(Office.PARAGRAPH_COUNT), properties);
-        putRawValue(KEY_WORD_COUNT, metadata.get(Office.WORD_COUNT), properties);
+        putRawValue(KEY_CREATE_DATETIME, metadata.get(Metadata.CREATION_DATE), properties);
+        putRawValue(KEY_LAST_SAVE_DATETIME, metadata.get(Metadata.LAST_SAVED), properties);
+        putRawValue(KEY_EDIT_TIME, metadata.get(Metadata.EDIT_TIME), properties);
+        putRawValue(KEY_FORMAT, metadata.get(Metadata.FORMAT), properties);
+        putRawValue(KEY_KEYWORDS, metadata.get(Metadata.KEYWORDS), properties);
+        putRawValue(KEY_LAST_AUTHOR, metadata.get(Metadata.LAST_AUTHOR), properties);
+        putRawValue(KEY_LAST_PRINTED, metadata.get(Metadata.LAST_PRINTED), properties);
+//       putRawValue(KEY_OS_VERSION, metadata.get(Metadata.OS_VERSION), properties);
+//       putRawValue(KEY_THUMBNAIL, metadata.get(Metadata.THUMBNAIL), properties);
+        putRawValue(KEY_PAGE_COUNT, metadata.get(Metadata.PAGE_COUNT), properties);
+        putRawValue(KEY_PARAGRAPH_COUNT, metadata.get(Metadata.PARAGRAPH_COUNT), properties);
+        putRawValue(KEY_WORD_COUNT, metadata.get(Metadata.WORD_COUNT), properties);
         return properties;
     }
 }

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/TikaAudioMetadataExtractor.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/metadataExtractors/TikaAudioMetadataExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -28,7 +28,6 @@ package org.alfresco.transformer.metadataExtractors;
 
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.metadata.XMPDM;
 import org.apache.tika.parser.CompositeParser;
 import org.apache.tika.parser.Parser;
@@ -149,12 +148,13 @@ public class TikaAudioMetadataExtractor extends AbstractTikaMetadataExtractor
      * @param metadata     the metadata extracted from the file
      * @return          the description
      */
+    @SuppressWarnings("deprecation")
     private String generateDescription(Metadata metadata)
     {
         StringBuilder result = new StringBuilder();
-        if (metadata.get(TikaCoreProperties.TITLE) != null)
+        if (metadata.get(Metadata.TITLE) != null)
         {
-            result.append(metadata.get(TikaCoreProperties.TITLE));
+            result.append(metadata.get(Metadata.TITLE));
             if (metadata.get(XMPDM.ALBUM) != null)
             {
                 result

--- a/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/tika/parsers/ExifToolParser.java
+++ b/alfresco-transform-tika/alfresco-transform-tika/src/main/java/org/alfresco/transformer/tika/parsers/ExifToolParser.java
@@ -44,9 +44,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.io.IOUtils;
+import org.apache.tika.io.NullOutputStream;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -57,7 +57,7 @@ import org.apache.tika.parser.external.ExternalParser;
 import org.apache.tika.parser.external.ExternalParsersFactory;
 import org.apache.tika.parser.image.ImageParser;
 import org.apache.tika.parser.image.TiffParser;
-import org.apache.tika.parser.image.JpegParser;
+import org.apache.tika.parser.jpeg.JpegParser;
 import org.apache.tika.sax.XHTMLContentHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -263,7 +263,7 @@ public class ExifToolParser extends ExternalParser {
      * stream of the given process to the given XHTML content handler.
      * The standard output stream is closed once fully processed.
      *
-     * @param stream stream
+     * @param process process
      * @param xhtml XHTML content handler
      * @throws SAXException if the XHTML SAX events could not be handled
      * @throws IOException if an input error occurred
@@ -315,13 +315,13 @@ public class ExifToolParser extends ExternalParser {
      * standard stream of the given process. Potential exceptions
      * are ignored, and the stream is closed once fully processed.
      *
-     * @param stream stream
+     * @param process process
      */
     private void ignoreStream(final InputStream stream) {
         Thread t = new Thread() {
             public void run() {
                 try {
-                    IOUtils.copy(stream, NullOutputStream.NULL_OUTPUT_STREAM);
+                    IOUtils.copy(stream, new NullOutputStream());
                 } catch (IOException e) {
                 } finally {
                     IOUtils.closeQuietly(stream);

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>
         <dependency.junit.version>4.13.2</dependency.junit.version>
         <dependency.cxf.version>3.5.0</dependency.cxf.version>
-        <dependency.tika.version>2.1.0</dependency.tika.version>
+        <dependency.tika.version>1.26</dependency.tika.version>
         <dependency.poi.version>4.1.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
 


### PR DESCRIPTION
Revert ATS-969 Tika upgrade 1.x -> 2.x (#493)

As the build is deleting the following, resulting in the release job failure
D	alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/license/THIRD-PARTY.properties
D	alfresco-transform-core-aio/alfresco-transform-core-aio/src/license/THIRD-PARTY.properties
D	alfresco-transform-tika/alfresco-transform-tika-boot/src/license/THIRD-PARTY.properties
D	alfresco-transform-tika/alfresco-transform-tika/src/license/THIRD-PARTY.properties