### PR TITLE
ATS-979 Spike alpine support for Tika

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,10 @@ jobs:
       before_script: travis_wait bash _ci/cache_artifacts.sh
       install: _ci/build.sh tika
       script: bash _ci/test.sh tika
+    - name: "Tika Alpine"
+      before_script: travis_wait bash _ci/cache_artifacts.sh
+      install: _ci/build.sh tika,alpine
+      script: bash _ci/test.sh tika,alpine
     - name: "All in One Transformer"
       before_script: travis_wait bash _ci/cache_artifacts.sh
       install: _ci/build.sh full-build

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ mvn clean install -Plocal,docker-it-setup
 ```
 > The `local` Maven profile builds local Docker images for each T-Engine.
 
+*NOTE*  for _alfresco-tika_ you can use alpine as base image:
+```bash
+mvn clean install -Plocal,docker-it-setup,tika,alpine
+```
+
 ### Artifacts
 
 #### Maven

--- a/_ci/build.sh
+++ b/_ci/build.sh
@@ -9,7 +9,7 @@ mvn -B -U -Dmaven.wagon.http.pool=false \
     clean install \
     -DadditionalOption=-Xdoclint:none -Dmaven.javadoc.skip=true \
     -DskipTests \
-    "-P$1,"
+    "-P$1"
 
 popd
 set +vex

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile.alpine
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/Dockerfile.alpine
@@ -1,0 +1,32 @@
+# Image provides a container in which to run Tika transformations for Alfresco Content Services.
+
+# Tika is from Apache. See the license at http://www.apache.org/licenses/LICENSE-2.0.
+
+FROM alpine:3.13.7
+
+RUN apk add --no-cache openjdk11-jre exiftool
+
+ENV JAVA_OPTS=""
+
+# Set default user information
+ARG GROUPNAME=Alfresco
+ARG GROUPID=1000
+ARG TIKAUSERNAME=tika
+ARG USERID=33004
+
+COPY target/${env.project_artifactId}-${env.project_version}.jar /usr/bin
+
+ADD target/generated-resources/licenses              /licenses
+ADD target/generated-resources/licenses.xml          /licenses/
+ADD target/generated-sources/license/THIRD-PARTY.txt /licenses/
+COPY src/main/resources/licenses/3rd-party/ /
+ 
+RUN addgroup -g ${GROUPID} -S ${GROUPNAME} && \
+    adduser -u ${USERID} -G ${GROUPNAME} -S ${TIKAUSERNAME} && \
+    chgrp -R ${GROUPNAME} /usr/bin/${env.project_artifactId}-*.jar
+
+EXPOSE 8090
+
+USER ${TIKAUSERNAME}
+
+ENTRYPOINT java $JAVA_OPTS -jar /usr/bin/${env.project_artifactId}-*.jar

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/pom.xml
@@ -12,7 +12,11 @@
     </parent>
 
     <properties>
+        <image.dockerFile>Dockerfile</image.dockerFile>
         <image.name>alfresco/alfresco-tika</image.name>
+        <image.tagBase>latest</image.tagBase>
+        <image.tagSuffix></image.tagSuffix>
+        <image.tag>${image.tagBase}${image.tagSuffix}</image.tag>
         <image.registry>quay.io</image.registry>
         <env.project_artifactId>${project.artifactId}</env.project_artifactId>
     </properties>
@@ -259,6 +263,7 @@
                                             <name>${image.name}:${image.tag}</name>
                                             <build>
                                                 <contextDir>${project.basedir}</contextDir>
+                                                <dockerFile>${image.dockerFile}</dockerFile>
                                                 <buildOptions>
                                                     <squash>true</squash>
                                                 </buildOptions>
@@ -288,6 +293,7 @@
                                     <registry>${image.registry}</registry>
                                     <build>
                                         <contextDir>${project.basedir}</contextDir>
+                                        <dockerFile>${image.dockerFile}</dockerFile>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -298,6 +304,7 @@
                                     <name>${image.name}:${image.tag}</name>
                                     <build>
                                         <contextDir>${project.basedir}</contextDir>
+                                        <dockerFile>${image.dockerFile}</dockerFile>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -334,6 +341,7 @@
                                     <registry>${image.registry}</registry>
                                     <build>
                                         <contextDir>${project.basedir}</contextDir>
+                                        <dockerFile>${image.dockerFile}</dockerFile>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -344,6 +352,7 @@
                                     <name>${image.name}:${project.version}</name>
                                     <build>
                                         <contextDir>${project.basedir}</contextDir>
+                                        <dockerFile>${image.dockerFile}</dockerFile>
                                         <buildOptions>
                                             <squash>true</squash>
                                         </buildOptions>
@@ -362,6 +371,14 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>alpine</id>
+            <properties>
+                <image.dockerFile>Dockerfile.alpine</image.dockerFile>
+                <image.tagSuffix>-alpine</image.tagSuffix>
+            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
* add alpine profile to tika project to build with custom Dockerfile.alpine and tag alpine-latest
* add new job to travis for Tika alpine
* use docker-maven-plugin to run as fabric8 breaks on rancher desktop

Ref. ATS-979