### PR TITLE
ACS-2587 Include directAccessUrl in T-Config if supported

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/main/java/org/alfresco/transformer/AIOTransformRegistry.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/main/java/org/alfresco/transformer/AIOTransformRegistry.java
@@ -86,7 +86,7 @@ public class AIOTransformRegistry extends AbstractTransformRegistry
         // Load config for the transformer
         String location = getTransformConfigLocation(tEngine);
         TransformConfig transformConfig = loadTransformConfig(location);
-        setCoreVersionOnSingleStepTransformers(transformConfig.getTransformers(), coreVersion);
+        setCoreVersionOnSingleStepTransformers(transformConfig, coreVersion);
         String transformerId = tEngine.getTransformerId();
         combinedTransformConfig.addTransformConfig(transformConfig, location, transformerId, this);
 

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/TransformRegistryImpl.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/TransformRegistryImpl.java
@@ -87,7 +87,7 @@ public class TransformRegistryImpl extends AbstractTransformRegistry
         try (Reader reader = new InputStreamReader(engineConfig.getInputStream(), UTF_8))
         {
             TransformConfig transformConfig = jsonObjectMapper.readValue(reader, TransformConfig.class);
-            setCoreVersionOnSingleStepTransformers(transformConfig.getTransformers(), coreVersion);
+            setCoreVersionOnSingleStepTransformers(transformConfig, coreVersion);
             return transformConfig;
         }
         catch (IOException e)

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency.pdfbox.version>2.0.25</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.12</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
-        <dependency.alfresco-transform-model.version>1.4.10</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.4.11</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.16.4</dependency.activemq.version>
         <dependency.jackson.version>2.13.1</dependency.jackson.version>
         <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-transform-core</artifactId>
-    <version>2.5.7-A4-SNAPSHOT</version>
+    <version>2.5.7-A4-SNAPSHOT</version> 
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
The t-config returned by the T-Router & T-Engines should include directAccessUrl as an optional transform option when the T-engine supports it.