### PR TITLE
ACS-2494 sourceReference may now be null with direct access urls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency.pdfbox.version>2.0.25</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.12</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
-        <dependency.alfresco-transform-model.version>1.4.11</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.4.13</dependency.alfresco-transform-model.version>
         <dependency.activemq.version>5.16.4</dependency.activemq.version>
         <dependency.jackson.version>2.13.1</dependency.jackson.version>
         <dependency.jackson-databind.version>${dependency.jackson.version}</dependency.jackson-databind.version>


### PR DESCRIPTION
* Pick up t-model 1.4.12 which has the check for this field

[trigger release] 2.5.7-A5