### PR TITLE
ACS-3118  Check the size of intermmitent results in a pipeline

### DIFF
--- a/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio-boot/src/main/java/org/alfresco/transformer/AIOController.java
@@ -71,12 +71,9 @@ public class AIOController extends AbstractTransformerController
         return getTransformerName() + " available";
     }
 
-    // TODO ATS-713 Currently uses the Misc probeTest. The implementation will need to be changed such that the test can be selected based on the required transform
     @Override
     public ProbeTestTransform getProbeTestTransform() 
     {
-        // HtmlParserContentTransformer html -> text
-        // See the Javadoc on this method and Probes.md for the choice of these values.
         return new ProbeTestTransform(this, "quick.html", "quick.txt",
             119, 30, 150, 1024,
             60 * 2 + 1, 60 * 2)
@@ -120,7 +117,6 @@ public class AIOController extends AbstractTransformerController
             logger.debug("Performing transform with name '{}' using transformer with id '{}'.", transformName, transformer.getTransformerId());
         }
 
-        transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
-        transformer.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+        transformer.transformExtractOrEmbed(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }
 }

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
+++ b/alfresco-transform-core-aio/alfresco-transform-core-aio/src/test/java/org/alfresco/transformer/AIOTransformRegistryTest.java
@@ -184,9 +184,8 @@ public class AIOTransformRegistryTest
 
             Map<String, String> parameters = new HashMap<>();
             parameters.put(SOURCE_ENCODING, "ISO-8859-1");
-            parameters.put(TRANSFORM_NAME_PARAMETER, "html");
             Transformer transformer = aioTransformerRegistry.getByTransformName("html");
-            transformer.transform(SOURCE_MIMETYPE, TARGET_MIMETYPE, parameters, tmpS, tmpD);
+            transformer.transformExtractOrEmbed("html", SOURCE_MIMETYPE, TARGET_MIMETYPE, parameters, tmpS, tmpD);
 
             assertEquals(expected, readFromFile(tmpD, "UTF-8"));
             tmpS.delete();
@@ -198,9 +197,8 @@ public class AIOTransformRegistryTest
 
             tmpD = File.createTempFile("AlfrescoTestTarget_", ".txt");
             parameters = new HashMap<>();
-            parameters.put(TRANSFORM_NAME_PARAMETER, "html");
             parameters.put(SOURCE_ENCODING, "UTF-8");
-            transformer.transform(SOURCE_MIMETYPE, TARGET_MIMETYPE, parameters, tmpS, tmpD);
+            transformer.transformExtractOrEmbed("html", SOURCE_MIMETYPE, TARGET_MIMETYPE, parameters, tmpS, tmpD);
             assertEquals(expected, readFromFile(tmpD, "UTF-8"));
             tmpS.delete();
             tmpD.delete();
@@ -211,9 +209,8 @@ public class AIOTransformRegistryTest
 
             tmpD = File.createTempFile("AlfrescoTestTarget_", ".txt");
             parameters = new HashMap<>();
-            parameters.put(TRANSFORM_NAME_PARAMETER, "html");
             parameters.put(SOURCE_ENCODING, "UTF-16");
-            transformer.transform(SOURCE_MIMETYPE, TARGET_MIMETYPE, parameters, tmpS, tmpD);
+            transformer.transformExtractOrEmbed("html", SOURCE_MIMETYPE, TARGET_MIMETYPE, parameters, tmpS, tmpD);
             assertEquals(expected, readFromFile(tmpD, "UTF-8"));
             tmpS.delete();
             tmpD.delete();
@@ -237,9 +234,8 @@ public class AIOTransformRegistryTest
             tmpD = File.createTempFile("AlfrescoTestTarget_", ".txt");
 
             parameters = new HashMap<>();
-            parameters.put(TRANSFORM_NAME_PARAMETER, "html");
             parameters.put(SOURCE_ENCODING, "ISO-8859-1");
-            transformer.transform(SOURCE_MIMETYPE, TARGET_MIMETYPE, parameters, tmpS, tmpD);
+            transformer.transformExtractOrEmbed("html", SOURCE_MIMETYPE, TARGET_MIMETYPE, parameters, tmpS, tmpD);
             assertEquals(expected, readFromFile(tmpD, "UTF-8"));
             tmpS.delete();
             tmpD.delete();
@@ -295,9 +291,8 @@ public class AIOTransformRegistryTest
         // Transform to PDF
         Map<String, String> parameters = new HashMap<>();
         parameters.put(PAGE_LIMIT, pageLimit);
-        parameters.put(TRANSFORM_NAME_PARAMETER, "textToPdf");
         Transformer transformer = aioTransformerRegistry.getByTransformName("textToPdf");
-        transformer.transform("text/plain", "application/pdf", parameters, sourceFile, targetFile);
+        transformer.transformExtractOrEmbed("textToPdf", "text/plain", "application/pdf", parameters, sourceFile, targetFile);
 
         // Read back in the PDF and check it
         PDDocument doc = PDDocument.load(targetFile);

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
@@ -126,6 +126,6 @@ public class  ImageMagickController extends AbstractTransformerController
     public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
                                  Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
-        commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+        commandExecutor.transformExtractOrEmbed(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }
 }

--- a/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
+++ b/alfresco-transform-imagemagick/alfresco-transform-imagemagick-boot/src/main/java/org/alfresco/transformer/ImageMagickController.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
+++ b/alfresco-transform-libreoffice/alfresco-transform-libreoffice-boot/src/main/java/org/alfresco/transformer/LibreOfficeController.java
@@ -128,6 +128,6 @@ public class LibreOfficeController extends AbstractTransformerController
     public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
                                  Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
-        javaExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+        javaExecutor.transformExtractOrEmbed(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }
 }

--- a/alfresco-transform-misc/alfresco-transform-misc-boot/src/main/java/org/alfresco/transformer/MiscController.java
+++ b/alfresco-transform-misc/alfresco-transform-misc-boot/src/main/java/org/alfresco/transformer/MiscController.java
@@ -83,7 +83,6 @@ public class MiscController extends AbstractTransformerController
     public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
                                  Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
-        transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
-        transformer.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+        transformer.transformExtractOrEmbed(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }
 }

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
@@ -113,6 +113,6 @@ public class AlfrescoPdfRendererController extends AbstractTransformerController
     public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
                                  Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
-        commandExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+        commandExecutor.transformExtractOrEmbed(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }
 }

--- a/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
+++ b/alfresco-transform-pdf-renderer/alfresco-transform-pdf-renderer-boot/src/main/java/org/alfresco/transformer/AlfrescoPdfRendererController.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import static org.alfresco.transformer.executors.Tika.PDF_BOX;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_PDF;
 import static org.alfresco.transformer.util.MimetypeMap.MIMETYPE_TEXT_PLAIN;
-import static org.alfresco.transformer.util.RequestParamMap.TRANSFORM_NAME_PARAMETER;
 
 /**
  * Controller for the Docker based Tika transformers.
@@ -107,7 +106,6 @@ public class TikaController extends AbstractTransformerController
     public void transformImpl(String transformName, String sourceMimetype, String targetMimetype,
                                  Map<String, String> transformOptions, File sourceFile, File targetFile)
     {
-        transformOptions.put(TRANSFORM_NAME_PARAMETER, transformName);
-        javaExecutor.transform(sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+        javaExecutor.transformExtractOrEmbed(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
     }
 }

--- a/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
+++ b/alfresco-transform-tika/alfresco-transform-tika-boot/src/main/java/org/alfresco/transformer/TikaController.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/AbstractTransformerController.java
@@ -352,6 +352,7 @@ public abstract class AbstractTransformerController implements TransformControll
             transformerDebug.logOptions(request);
             String transformName = getTransformerName(sourceFile, sourceMimetype, targetMimetype, transformOptions);
             transformImpl(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+            reply.getInternalContext().setCurrentSourceSize(targetFile.length());
         }
         catch (TransformException e)
         {

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/executors/Transformer.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/executors/Transformer.java
@@ -51,12 +51,12 @@ public interface Transformer
      */
     String getTransformerId();
 
-    default void transform(String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
-                           File sourceFile, File targetFile) throws TransformException
+    default void transformExtractOrEmbed(String transformName, String sourceMimetype, String targetMimetype,
+                                         Map<String, String> transformOptions,
+                                         File sourceFile, File targetFile) throws TransformException
     {
         try
         {
-            final String transformName = transformOptions.remove(TRANSFORM_NAME_PARAMETER);
             if (MIMETYPE_METADATA_EXTRACT.equals(targetMimetype))
             {
                 extractMetadata(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);

--- a/alfresco-transformer-base/src/main/java/org/alfresco/transformer/executors/Transformer.java
+++ b/alfresco-transformer-base/src/main/java/org/alfresco/transformer/executors/Transformer.java
@@ -4,7 +4,7 @@ package org.alfresco.transformer.executors;
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -50,6 +50,12 @@ public interface Transformer
      *
      */
     String getTransformerId();
+
+    default void transform(String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
+                           File sourceFile, File targetFile) throws TransformException {
+        final String transformName = transformOptions.remove(TRANSFORM_NAME_PARAMETER);
+        transformExtractOrEmbed(transformName, sourceMimetype, targetMimetype, transformOptions, sourceFile, targetFile);
+    }
 
     default void transformExtractOrEmbed(String transformName, String sourceMimetype, String targetMimetype,
                                          Map<String, String> transformOptions,


### PR DESCRIPTION
Set the size of a transform result in the Reply to the t-router.

Tidy up code: Avoid having to add the transformName to the transformOptions in the Controller class and then remove it in Transformer interface.