### PR TITLE
ACS-3476: Re-adding a getAdditional method

### DIFF
--- a/engines/base/src/main/java/org/alfresco/transform/base/registry/TransformConfigFilesHistoric.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/registry/TransformConfigFilesHistoric.java
@@ -50,6 +50,11 @@ public class TransformConfigFilesHistoric
     // environment variables like TRANSFORMER_ROUTES_ADDITIONAL_<engineName>.
     private final Map<String, String> additional = new HashMap<>();
 
+    //Used by ConfigurationProperties annotation
+    public Map<String, String> getAdditional() {
+        return additional;
+    }
+
     private String TRANSFORMER_ROUTES_FROM_CLASSPATH = "transformer-pipelines.json";
 
     @Value("${transformer-routes-path}")


### PR DESCRIPTION
It was needed for proper processing of ConfigurationProperties annotation and allowing for TRANSFORMER_ROUTES_ADDITIONAL_<engineName> for backwards compatibility. Spring mechanism takes the "transform.routes" gets the "additional" as a setting and adds to map ("ai", configFile). Without this get, the spring mechanism can't add this property due to no access to additional variable