### PR TITLE
ACS-4739 Fix intermittent tests failures due to CustomTransformers

### DIFF
--- a/engines/base/src/test/java/org/alfresco/transform/base/TransformControllerAllInOneTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/TransformControllerAllInOneTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * Copyright (C) 2005 - 2023 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -44,6 +44,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.nio.charset.StandardCharsets;
 import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
 
 import static org.alfresco.transform.base.TransformControllerTest.assertConfig;
 import static org.alfresco.transform.base.TransformControllerTest.getLogMessagesFor;
@@ -63,6 +64,7 @@ import static org.alfresco.transform.common.RequestParamMap.ENDPOINT_VERSION;
 import static org.alfresco.transform.common.RequestParamMap.PAGE_REQUEST_PARAM;
 import static org.alfresco.transform.common.RequestParamMap.SOURCE_MIMETYPE;
 import static org.alfresco.transform.common.RequestParamMap.TARGET_MIMETYPE;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -197,31 +199,34 @@ public class TransformControllerAllInOneTest
     @Test
     public void testTransformEndpointUsingTransformEngineWithTwoCustomTransformers() throws Exception
     {
-        mockMvc.perform(
-            MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
-                .file(new MockMultipartFile("file", null, MIMETYPE_TEXT_PLAIN,
-                    "Start".getBytes(StandardCharsets.UTF_8)))
-                .param(SOURCE_MIMETYPE, MIMETYPE_TEXT_PLAIN)
-                .param(TARGET_MIMETYPE, MIMETYPE_PDF)
-                .param(PAGE_REQUEST_PARAM, "1"))
-            .andExpect(status().isOk())
-            .andExpect(header().string("Content-Disposition",
-            "attachment; filename*=UTF-8''transform.pdf"))
-            .andExpect(content().string("Start -> TxT2Pdf(page=1)"));
+      await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(() -> mockMvc.perform(
+                  MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
+                      .file(new MockMultipartFile("file", null, MIMETYPE_TEXT_PLAIN,
+                          "Start".getBytes(StandardCharsets.UTF_8)))
+                      .param(SOURCE_MIMETYPE, MIMETYPE_TEXT_PLAIN)
+                      .param(TARGET_MIMETYPE, MIMETYPE_PDF)
+                      .param(PAGE_REQUEST_PARAM, "1"))
+              .andExpect(status().isOk())
+              .andExpect(header().string("Content-Disposition",
+                  "attachment; filename*=UTF-8''transform.pdf"))
+              .andExpect(content().string("Start -> TxT2Pdf(page=1)")));
     }
 
-    @Test
-    public void testTransformEndpointUsingTransformEngineWithOneCustomTransformer() throws Exception
-    {
-        mockMvc.perform(
-            MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
-                .file(new MockMultipartFile("file", null, MIMETYPE_PDF,
-                    "Start".getBytes(StandardCharsets.UTF_8)))
-                .param(SOURCE_MIMETYPE, MIMETYPE_PDF)
-                .param(TARGET_MIMETYPE, MIMETYPE_IMAGE_JPEG))
-            .andExpect(status().isOk())
-            .andExpect(header().string("Content-Disposition",
-                "attachment; filename*=UTF-8''transform.jpeg"))
-            .andExpect(content().string("Start -> Pdf2Jpg()"));
-    }
+     @Test
+     public void testTransformEndpointUsingTransformEngineWithOneCustomTransformer() throws Exception {
+       await()
+           .atMost(10, TimeUnit.SECONDS)
+           .untilAsserted(() -> mockMvc.perform(
+                   MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
+                       .file(new MockMultipartFile("file", null, MIMETYPE_PDF,
+                           "Start".getBytes(StandardCharsets.UTF_8)))
+                       .param(SOURCE_MIMETYPE, MIMETYPE_PDF)
+                       .param(TARGET_MIMETYPE, MIMETYPE_IMAGE_JPEG))
+               .andExpect(status().isOk())
+               .andExpect(header().string("Content-Disposition",
+                   "attachment; filename*=UTF-8''transform.jpeg"))
+               .andExpect(content().string("Start -> Pdf2Jpg()")));
+     }
 }

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/FragmentHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/FragmentHandlerTest.java
@@ -149,15 +149,15 @@ public class FragmentHandlerTest
     public void testErrorIfHttp() {
         String expectedError = "Fragments may only be sent via message queues. This an http request";
         await()
-        .atMost(1, TimeUnit.MINUTES)
-        .untilAsserted(() -> mockMvc.perform(
-                MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
-                    .file(new MockMultipartFile("file", null, MIMETYPE_TEXT_PLAIN,
-                        "Start".getBytes(StandardCharsets.UTF_8)))
-                    .param(SOURCE_MIMETYPE, MIMETYPE_PDF)
-                    .param(TARGET_MIMETYPE, MIMETYPE_IMAGE_JPEG))
-            .andExpect(status().isInternalServerError())
-            .andExpect(status().reason(containsString(expectedError))));
+            .atMost(1, TimeUnit.MINUTES)
+            .untilAsserted(() -> mockMvc.perform(
+                    MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
+                        .file(new MockMultipartFile("file", null, MIMETYPE_TEXT_PLAIN,
+                            "Start".getBytes(StandardCharsets.UTF_8)))
+                        .param(SOURCE_MIMETYPE, MIMETYPE_PDF)
+                        .param(TARGET_MIMETYPE, MIMETYPE_IMAGE_JPEG))
+                .andExpect(status().isInternalServerError())
+                .andExpect(status().reason(containsString(expectedError))));
     }
 
     @Test

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/FragmentHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/FragmentHandlerTest.java
@@ -149,7 +149,7 @@ public class FragmentHandlerTest
     public void testErrorIfHttp() {
         String expectedError = "Fragments may only be sent via message queues. This an http request";
         await()
-            .atMost(1, TimeUnit.MINUTES)
+            .atMost(10, TimeUnit.SECONDS)
             .untilAsserted(() -> mockMvc.perform(
                     MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
                         .file(new MockMultipartFile("file", null, MIMETYPE_TEXT_PLAIN,

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/FragmentHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/FragmentHandlerTest.java
@@ -61,9 +61,7 @@ import static org.alfresco.transform.base.transform.StreamHandlerTest.read;
 import static org.alfresco.transform.common.Mimetype.MIMETYPE_IMAGE_JPEG;
 import static org.alfresco.transform.common.Mimetype.MIMETYPE_PDF;
 import static org.alfresco.transform.common.Mimetype.MIMETYPE_TEXT_PLAIN;
-import static org.alfresco.transform.common.RequestParamMap.ENDPOINT_TRANSFORM;
-import static org.alfresco.transform.common.RequestParamMap.SOURCE_MIMETYPE;
-import static org.alfresco.transform.common.RequestParamMap.TARGET_MIMETYPE;
+import static org.alfresco.transform.common.RequestParamMap.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -156,7 +154,8 @@ public class FragmentHandlerTest
                 .file(new MockMultipartFile("file", null, MIMETYPE_TEXT_PLAIN,
                  "Start".getBytes(StandardCharsets.UTF_8)))
                 .param(SOURCE_MIMETYPE, MIMETYPE_PDF)
-                .param(TARGET_MIMETYPE, MIMETYPE_IMAGE_JPEG))
+                .param(TARGET_MIMETYPE, MIMETYPE_IMAGE_JPEG)
+                .param(TIMEOUT, "60000"))
                .andExpect(status().isInternalServerError())
                .andExpect(status().reason(containsString(expectedError)));
     }

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/FragmentHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/FragmentHandlerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Transform Core
  * %%
- * Copyright (C) 2022 - 2022 Alfresco Software Limited
+ * Copyright (C) 2022 - 2023 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * -
@@ -56,12 +56,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.alfresco.transform.base.transform.StreamHandlerTest.read;
-import static org.alfresco.transform.common.Mimetype.MIMETYPE_IMAGE_JPEG;
-import static org.alfresco.transform.common.Mimetype.MIMETYPE_PDF;
-import static org.alfresco.transform.common.Mimetype.MIMETYPE_TEXT_PLAIN;
+import static org.alfresco.transform.common.Mimetype.*;
 import static org.alfresco.transform.common.RequestParamMap.*;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -146,18 +146,18 @@ public class FragmentHandlerTest
     }
 
     @Test
-    public void testErrorIfHttp() throws Exception
-    {
+    public void testErrorIfHttp() {
         String expectedError = "Fragments may only be sent via message queues. This an http request";
-        mockMvc.perform(
-            MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
-                .file(new MockMultipartFile("file", null, MIMETYPE_TEXT_PLAIN,
-                 "Start".getBytes(StandardCharsets.UTF_8)))
-                .param(SOURCE_MIMETYPE, MIMETYPE_PDF)
-                .param(TARGET_MIMETYPE, MIMETYPE_IMAGE_JPEG)
-                .param(TIMEOUT, "60000"))
-               .andExpect(status().isInternalServerError())
-               .andExpect(status().reason(containsString(expectedError)));
+        await()
+        .atMost(1, TimeUnit.MINUTES)
+        .untilAsserted(() -> mockMvc.perform(
+                MockMvcRequestBuilders.multipart(ENDPOINT_TRANSFORM)
+                    .file(new MockMultipartFile("file", null, MIMETYPE_TEXT_PLAIN,
+                        "Start".getBytes(StandardCharsets.UTF_8)))
+                    .param(SOURCE_MIMETYPE, MIMETYPE_PDF)
+                    .param(TARGET_MIMETYPE, MIMETYPE_IMAGE_JPEG))
+            .andExpect(status().isInternalServerError())
+            .andExpect(status().reason(containsString(expectedError))));
     }
 
     @Test


### PR DESCRIPTION
Fixes the occasional race condition between the test looking for the custom transformer vs ATS adding the custom transformer to the registry:
https://github.com/Alfresco/alfresco-transform-core/blob/babe26b0ba29a40fa8478813a5e416ec7930352e/engines/base/src/main/java/org/alfresco/transform/base/registry/TransformRegistry.java#L154-L162

**Example of failure before the fix**: https://github.com/Alfresco/alfresco-transform-core/actions/runs/4279090922/jobs/7457207601#step:11:956

**Relevant error**: 
```
05:06:47.533 [main] DEBUG o.a.t.common.TransformerDebug - e1                  Error: No transforms for: application/pdf (5 bytes) -> image/jpeg 
05:06:47.534 [main] DEBUG o.a.t.common.TransformerDebug - e1                Finished in 0 ms
```