### PR TITLE
[ACS-4460] change EndpointIdentificationAlgorithm from null to empty …

### DIFF
--- a/engines/base/src/main/java/org/alfresco/transform/base/config/MTLSConfig.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/config/MTLSConfig.java
@@ -170,7 +170,7 @@ public class MTLSConfig {
             SSLParameters sslParameters = sslEngine.getSSLParameters();
             if(hostNameVerificationDisabled)
             {
-                sslParameters.setEndpointIdentificationAlgorithm(null);
+                sslParameters.setEndpointIdentificationAlgorithm("");
             } else {
                 sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
             }


### PR DESCRIPTION
…string (null does not work - is overwritten by "HTTPS" by default)