### PR TITLE
Change to Poolable connection manager, due to RestTemplate provided f…

### DIFF
--- a/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/config/MTLSConfig.java
+++ b/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/config/MTLSConfig.java
@@ -29,7 +29,7 @@ package org.alfresco.transformer.config;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
@@ -139,7 +139,7 @@ public class MTLSConfig {
                         .register("https", sslConnectionSocketFactory)
                         .build();
 
-        final BasicHttpClientConnectionManager sslConnectionManager = new BasicHttpClientConnectionManager(sslSocketFactoryRegistry);
+        final PoolingHttpClientConnectionManager sslConnectionManager = new PoolingHttpClientConnectionManager(sslSocketFactoryRegistry);
 
         HttpClientBuilder httpClientBuilder = HttpClients.custom().setConnectionManager(sslConnectionManager);
         CloseableHttpClient httpClient = httpClientBuilder.build();

--- a/engines/base/src/main/java/org/alfresco/transform/base/config/MTLSConfig.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/config/MTLSConfig.java
@@ -32,7 +32,7 @@ import org.alfresco.transform.base.WebClientBuilderAdjuster;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
@@ -198,7 +198,7 @@ public class MTLSConfig {
                         .register("https", sslConnectionSocketFactory)
                         .build();
 
-        final BasicHttpClientConnectionManager sslConnectionManager = new BasicHttpClientConnectionManager(sslSocketFactoryRegistry);
+        final PoolingHttpClientConnectionManager sslConnectionManager = new PoolingHttpClientConnectionManager(sslSocketFactoryRegistry);
 
         HttpClientBuilder httpClientBuilder = HttpClients.custom().setConnectionManager(sslConnectionManager);
         CloseableHttpClient httpClient = httpClientBuilder.build();

--- a/engines/base/src/test/java/org/alfresco/transform/base/MtlsTestUtils.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/MtlsTestUtils.java
@@ -28,7 +28,7 @@ package org.alfresco.transform.base;
 
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
@@ -111,7 +111,7 @@ public class MtlsTestUtils {
                         .register("https", sslConnectionSocketFactory)
                         .build();
 
-        return new BasicHttpClientConnectionManager(sslSocketFactoryRegistry);
+        return new PoolingHttpClientConnectionManager(sslSocketFactoryRegistry);
     }
 
     public static RestTemplate restTemplateWithMtls()


### PR DESCRIPTION
…or mTLS being a singleton - possible reuse of connections or multithreaded usage