### PR TITLE
ACS-6653 Bump Tika, PDFBox, POI and commons-compress

### DIFF
--- a/engines/misc/pom.xml
+++ b/engines/misc/pom.xml
@@ -57,17 +57,6 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>${dependency.poi.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.poi</groupId>
-                    <artifactId>poi-ooxml-schemas</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi-ooxml-lite</artifactId>
-            <version>${dependency.poi-ooxml-lite.version}</version>
         </dependency>
 
         <!-- EMLTransformer -->

--- a/engines/tika/pom.xml
+++ b/engines/tika/pom.xml
@@ -63,14 +63,6 @@
             <version>${dependency.tika.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcmail-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>xml-apis</groupId>
                     <artifactId>xml-apis</artifactId>
                 </exclusion>
@@ -82,18 +74,6 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.12.5</version>
-        </dependency>
-
-        <!-- for Apache Tika Parsers - eg. encrypted PDF -->
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15to18</artifactId>
-            <version>1.76</version>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk15on</artifactId>
-            <version>1.70</version>
         </dependency>
 
         <!-- Apache POI -->

--- a/engines/tika/pom.xml
+++ b/engines/tika/pom.xml
@@ -86,17 +86,6 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>${dependency.poi.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.poi</groupId>
-                    <artifactId>poi-ooxml-schemas</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi-ooxml-lite</artifactId>
-            <version>${dependency.poi-ooxml-lite.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
         <dependency.jackson.version>2.15.2</dependency.jackson.version>
         <dependency.tika.version>2.9.1</dependency.tika.version>
         <dependency.poi.version>5.2.5</dependency.poi.version>
-        <dependency.poi-ooxml-lite.version>5.2.5</dependency.poi-ooxml-lite.version>
         <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
 
         <parent.core.deploy.skip>false</parent.core.deploy.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
 
         <image.tag>latest</image.tag>
         <image.registry>quay.io</image.registry>
-        <dependency.pdfbox.version>2.0.26</dependency.pdfbox.version>
+        <dependency.pdfbox.version>2.0.30</dependency.pdfbox.version>
         <dependency.alfresco-jodconverter-core.version>3.0.1.18</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
         <dependency.jackson.version>2.15.2</dependency.jackson.version>
-        <dependency.tika.version>2.4.1</dependency.tika.version>
-        <dependency.poi.version>5.2.2</dependency.poi.version>
-        <dependency.poi-ooxml-lite.version>5.2.4</dependency.poi-ooxml-lite.version>
+        <dependency.tika.version>2.9.1</dependency.tika.version>
+        <dependency.poi.version>5.2.5</dependency.poi.version>
+        <dependency.poi-ooxml-lite.version>5.2.5</dependency.poi-ooxml-lite.version>
         <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
 
         <parent.core.deploy.skip>false</parent.core.deploy.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.24.0</version>
+                <version>1.25.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Bumping Tika, PDFBox, POI and commons-compress to the latest non-major upgrade. Bumping all of these together as some of their dependencies are intertwined and it's a faster way of verifying everything still works after the upgrade + the dependency tree looks fairly clean.

**NOTES:**
- decided to omit the `bouncycastle` dependencies override as we're now relying on the same version required by Tika instead, which is way newer than the last override we started to maintain years ago. We can re-introduce this in the future if we see Tika lags considerably behind our security necessities when it comes down to `bouncycastle`, but it's not needed in this point in time as `bouncycastle 1.76` is free from known security issues.
- removed unnecessary `poi-ooxml-lite` / `poi-ooxml-schemas` dependency management. `poi-ooxml-schemas` is not a transitive dependency therefore the exclusion does nothing. `poi-ooxml-lite` should always match the `poi` version and it automatically comes as a transitive dependency of `poi-ooxml`.