### PR TITLE
[ACS-6935] Remove mime4j dependency and bump tika version to 2.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,7 @@
         <dependency.alfresco-jodconverter-core.version>3.0.1.18</dependency.alfresco-jodconverter-core.version>
         <env.project_version>${project.version}</env.project_version>
         <dependency.jackson.version>2.16.1</dependency.jackson.version>
-        <dependency.tika.version>2.9.1</dependency.tika.version>
-        <dependency.mime4j.version>0.8.11</dependency.mime4j.version>
+        <dependency.tika.version>2.9.2</dependency.tika.version>
         <dependency.poi.version>5.2.5</dependency.poi.version>
         <dependency.snakeyaml.version>2.2</dependency.snakeyaml.version>
 
@@ -173,17 +172,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>1.26.0</version>
-            </dependency>
-            <!-- Apache James - Mime4j -->
-            <dependency>
-                <groupId>org.apache.james</groupId>
-                <artifactId>apache-mime4j-core</artifactId>
-                <version>${dependency.mime4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.james</groupId>
-                <artifactId>apache-mime4j-dom</artifactId>
-                <version>${dependency.mime4j.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
As per title.

Dependency tree:
[INFO] |  +- org.apache.tika:tika-parser-mail-module:jar:2.9.2:compile
[INFO] |  |  +- org.apache.tika:tika-parser-mail-commons:jar:2.9.2:compile
[INFO] |  |  |  +- org.apache.james:apache-mime4j-core:jar:0.8.11:compile
[INFO] |  |  |  |  \- (commons-io:commons-io:jar:2.11.0:compile - omitted for conflict with 2.15.1)
[INFO] |  |  |  \- org.apache.james:apache-mime4j-dom:jar:0.8.11:compile
[INFO] |  |  |     +- (org.apache.james:apache-mime4j-core:jar:0.8.11:compile - omitted for duplicate)
Full dependency tree: 
[tree.log](https://github.com/Alfresco/alfresco-transform-core/files/14930579/tree.log)


