### PR TITLE
ACS-6305 Fix Pipeline scan detecting 3rd party libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
       - name: "Build"
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
+        # Removing the aspectjweaver and bouncycastle jars from the scan, since Veracode detects them as 1st party code and fails the scan. TO BE REVERTED ONCE VERACODE FIXES THE ISSUE
         run:  |
           mkdir -p to-scan
           for file in engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
@@ -91,7 +92,6 @@ jobs:
               mv "$file" to-scan/
             fi
           done
-# Removing the aspectjweaver and bouncycastle jars from the scan, since Veracode detects them as 1st party code and fails the scan. TO BE REMOVED ONCE VERACODE FIXES THE ISSUE
           zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar" "BOOT-INF/lib/aspectjweaver*.jar"
           zip -r to-scan.zip to-scan
       - name: "Run SAST Scan"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
             fi
           done
           zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar" "BOOT-INF/lib/asm*.jar"
+          zip -d to-scan/alfresco-base*.jar "BOOT-INF/lib/asm*.jar"
           zip -r to-scan.zip to-scan
       - name: "Run SAST Scan"
         uses: veracode/Veracode-pipeline-scan-action@v1.0.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
           summary_output_file: results.json
           summary_display: true
           baseline_file: baseline.json
-          include: "*alfresco*"
       - name: Upload scan result
         if: success() || failure()
         run: zip readable_output.zip results.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: "Build"
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
-        run: zip -r to-scan.zip engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
+        run: zip -r to-scan.zip engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar -x *javadoc.jar *sources.jar
       - name: "Run SAST Scan"
         uses: veracode/Veracode-pipeline-scan-action@v1.0.10
         with:
@@ -98,6 +98,7 @@ jobs:
           summary_output_file: results.json
           summary_display: true
           baseline_file: baseline.json
+          include: "*alfresco*"
       - name: Upload scan result
         if: success() || failure()
         run: zip readable_output.zip results.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           summary_output_file: results.json
           summary_display: true
           baseline_file: baseline.json
-          include: "engines/aio/*"
+          include: "to-scan/alfresco-transform*"
       - name: Upload scan result
         if: success() || failure()
         run: zip readable_output.zip results.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
           summary_output_file: results.json
           summary_display: true
           baseline_file: baseline.json
+          include: "engines/aio/*"
       - name: Upload scan result
         if: success() || failure()
         run: zip readable_output.zip results.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
               mv "$file" to-scan/
             fi
           done
-          zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar"
+          zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar" "BOOT-INF/lib/asm*.jar"
           zip -r to-scan.zip to-scan
       - name: "Run SAST Scan"
         uses: veracode/Veracode-pipeline-scan-action@v1.0.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       - name: "Build"
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
-        # Removing the aspectjweaver and bouncycastle jars from the scan, since Veracode detects them as 1st party code and fails the scan. TO BE REVERTED ONCE VERACODE FIXES THE ISSUE
         run:  |
           mkdir -p to-scan
           for file in engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
@@ -92,6 +91,7 @@ jobs:
               mv "$file" to-scan/
             fi
           done
+          # Removing the aspectjweaver and bouncycastle jars from the scan, since Veracode detects them as 1st party code and fails the scan. TO BE REVERTED ONCE VERACODE FIXES THE ISSUE
           zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar" "BOOT-INF/lib/aspectjweaver*.jar"
           zip -r to-scan.zip to-scan
       - name: "Run SAST Scan"
@@ -108,7 +108,7 @@ jobs:
           summary_output_file: results.json
           summary_display: true
           baseline_file: baseline.json
-          include: "to-scan/alfresco-transform*"
+          include: "to-scan/alfresco*"
       - name: Upload scan result
         if: success() || failure()
         run: zip readable_output.zip results.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
       - name: "Build"
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
-        run: zip -r to-scan.zip engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar -x *javadoc.jar *sources.jar
+        run:  |
+          zip -d $jarfile 'bcmail-jdk18on' 'bcprov-jdk18on' engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
+          zip -r to-scan.zip engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar -x *javadoc.jar *sources.jar
       - name: "Run SAST Scan"
         uses: veracode/Veracode-pipeline-scan-action@v1.0.10
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,15 @@ jobs:
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
         run:  |
-          zip -d engines/aio/target/alfresco-transform-core-aio-*.jar 'BOOT-INF/lib/bcmail-jdk18on-*.jar' 'BOOT-INF/lib/bcprov-jdk18on-*.jar'
-          zip -d engines/base/target/alfresco-base-t-engine-*.jar 'BOOT-INF/lib/bcmail-jdk18on-*.jar' 'BOOT-INF/lib/bcprov-jdk18on-*.jar'
-          zip -d model/target/alfresco-transform-model-*.jar 'BOOT-INF/lib/bcmail-jdk18on-*.jar' 'BOOT-INF/lib/bcprov-jdk18on-*.jar'
-          zip -r to-scan.zip engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar -x *javadoc.jar *sources.jar
+          mkdir -p to-scan
+          for file in engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
+          do
+            if [[ $file != *javadoc.jar ]] && [[ $file != *sources.jar ]] && [[ $file != *tests.jar ]]; then
+              mv "$file" to-scan/
+            fi
+          done
+          zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar"
+          zip -r to-scan.zip to-scan
       - name: "Run SAST Scan"
         uses: veracode/Veracode-pipeline-scan-action@v1.0.10
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: "Build"
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
-        run:  |
+        run: |
           mkdir -p to-scan
           for file in engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
           do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
         run:  |
-          zip -d engines/aio/target/alfresco-transform-core-aio-*.jar 'bcmail-jdk18on' 'bcprov-jdk18on'
-          zip -d engines/base/target/alfresco-base-t-engine-*.jar 'bcmail-jdk18on' 'bcprov-jdk18on'
-          zip -d model/target/alfresco-transform-model-*.jar 'bcmail-jdk18on' 'bcprov-jdk18on'
+          zip -d engines/aio/target/alfresco-transform-core-aio-*.jar 'BOOT-INF/lib/bcmail-jdk18on-*.jar' 'BOOT-INF/lib/bcprov-jdk18on-*.jar'
+          zip -d engines/base/target/alfresco-base-t-engine-*.jar 'BOOT-INF/lib/bcmail-jdk18on-*.jar' 'BOOT-INF/lib/bcprov-jdk18on-*.jar'
+          zip -d model/target/alfresco-transform-model-*.jar 'BOOT-INF/lib/bcmail-jdk18on-*.jar' 'BOOT-INF/lib/bcprov-jdk18on-*.jar'
           zip -r to-scan.zip engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar -x *javadoc.jar *sources.jar
       - name: "Run SAST Scan"
         uses: veracode/Veracode-pipeline-scan-action@v1.0.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: "Build"
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
-        run:  |
+        run: |
           mkdir -p to-scan
           for file in engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
           do
@@ -91,6 +91,7 @@ jobs:
               mv "$file" to-scan/
             fi
           done
+# Removing the aspectjweaver and bouncycastle jars from the scan, since Veracode detects them as 1st party code and fails the scan. TO BE REMOVED ONCE VERACODE FIXES THE ISSUE
           zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar" "BOOT-INF/lib/aspectjweaver*.jar"
           zip -r to-scan.zip to-scan
       - name: "Run SAST Scan"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,9 @@ jobs:
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
         run:  |
-          zip -d $jarfile 'bcmail-jdk18on' 'bcprov-jdk18on' engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
+          zip -d engines/aio/target/alfresco-transform-core-aio-*.jar 'bcmail-jdk18on' 'bcprov-jdk18on'
+          zip -d engines/base/target/alfresco-base-t-engine-*.jar 'bcmail-jdk18on' 'bcprov-jdk18on'
+          zip -d model/target/alfresco-transform-model-*.jar 'bcmail-jdk18on' 'bcprov-jdk18on'
           zip -r to-scan.zip engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar -x *javadoc.jar *sources.jar
       - name: "Run SAST Scan"
         uses: veracode/Veracode-pipeline-scan-action@v1.0.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,7 @@ jobs:
               mv "$file" to-scan/
             fi
           done
-          zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar" "BOOT-INF/lib/asm*.jar"
-          zip -d to-scan/alfresco-base*.jar "BOOT-INF/lib/asm*.jar"
+          zip -d to-scan/alfresco-transform*.jar "BOOT-INF/lib/bcmail-jdk18on-*.jar" "BOOT-INF/lib/bcprov-jdk18on-*.jar" "BOOT-INF/lib/aspectjweaver*.jar"
           zip -r to-scan.zip to-scan
       - name: "Run SAST Scan"
         uses: veracode/Veracode-pipeline-scan-action@v1.0.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: "Build"
         run: mvn -B -U install -DskipTests
       - name: "Create zip"
-        run: |
+        run:  |
           mkdir -p to-scan
           for file in engines/aio/target/alfresco-transform-core-aio-*.jar engines/base/target/alfresco-base-t-engine-*.jar model/target/alfresco-transform-model-*.jar
           do


### PR DESCRIPTION
For some reason, after [this change](https://github.com/Alfresco/alfresco-transform-core/commit/7a2a7708672a65b595cb72747504b9e7deb399f3) Veracode started picking up bouncycastle and aspectjweaver as our own code instead of 3rd party library. Temporarily removing them from the package we send for scanning until this issue is resolved.