### PR TITLE
ACS-6305 Revert temporary Veracode scan fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
           zip -r to-scan.zip to-scan
       - name: "Run SAST Scan"
-        uses: veracode/Veracode-pipeline-scan-action@v1.0.10
+        uses: veracode/Veracode-pipeline-scan-action@v1.0.15
         with:
           vid: ${{ secrets.VERACODE_API_ID }}
           vkey: ${{ secrets.VERACODE_API_KEY }}


### PR DESCRIPTION
Should have been fixed by Veracode as part of https://docs.veracode.com/updates/r/c_all_static#may-23-2024, but it seems it's not the case.