### PR TITLE
ACS-8421 [release] Transform Core 5.1.4-A1 [skip tests]

### DIFF
--- a/_ci/cache_artifacts.sh
+++ b/_ci/cache_artifacts.sh
@@ -9,7 +9,7 @@ LIBREOFFICE_VERSION=7.2.5
 
 # Cache the LibreOffice distribution, as it is takes a long time to download and it can cause the
 # build to fail (no output for more than 10 minutes)
-LIBREOFFICE_RPM_URL="https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/libreoffice/libreoffice-dist/${LIBREOFFICE_VERSION}/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz"
+LIBREOFFICE_RPM_URL="https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/libreoffice/libreoffice-dist/${LIBREOFFICE_VERSION}/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz"
 if [ -f "${HOME}/artifacts/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz" ]; then
     echo "Using cached LibreOffice distribution..."
 else

--- a/deprecated/alfresco-transformer-base/pom.xml
+++ b/deprecated/alfresco-transformer-base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/aio/Dockerfile
+++ b/engines/aio/Dockerfile
@@ -9,14 +9,14 @@ FROM alfresco/alfresco-base-java:jre17-rockylinux8-202306121108
 
 ARG EXIFTOOL_VERSION=12.25
 ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}
-ARG EXIFTOOL_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/exiftool/image-exiftool/${EXIFTOOL_VERSION}/image-exiftool-${EXIFTOOL_VERSION}.tgz
+ARG EXIFTOOL_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/exiftool/image-exiftool/${EXIFTOOL_VERSION}/image-exiftool-${EXIFTOOL_VERSION}.tgz
 
 ARG IMAGEMAGICK_VERSION=7.1.0-16
-ENV IMAGEMAGICK_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}-ci-3/imagemagick-distribution-${IMAGEMAGICK_VERSION}-ci-3
+ENV IMAGEMAGICK_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}-ci-3/imagemagick-distribution-${IMAGEMAGICK_VERSION}-ci-3
 ENV IMAGEMAGICK_DEP_RPM_URL=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
 ARG LIBREOFFICE_VERSION=7.2.5
-ENV LIBREOFFICE_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/libreoffice/libreoffice-dist/${LIBREOFFICE_VERSION}/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz
+ENV LIBREOFFICE_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/libreoffice/libreoffice-dist/${LIBREOFFICE_VERSION}/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz
 ENV LIBREOFFICE_ARM64_RPM_URL=https://dl.rockylinux.org/pub/rocky/8/Devel/aarch64/os/Packages/l/
 ENV LIBREOFFICE_ARM64_RPM_VERSION=libreoffice-6.4.7.2
 ARG PDF_RENDERER_VERSION=1.2

--- a/engines/aio/Dockerfile
+++ b/engines/aio/Dockerfile
@@ -20,8 +20,8 @@ ENV LIBREOFFICE_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositor
 ENV LIBREOFFICE_ARM64_RPM_URL=https://dl.rockylinux.org/pub/rocky/8/Devel/aarch64/os/Packages/l/
 ENV LIBREOFFICE_ARM64_RPM_VERSION=libreoffice-6.4.7.2
 ARG PDF_RENDERER_VERSION=1.2
-ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux.tgz
-ENV ALFRESCO_PDF_RENDERER_ARM64_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux-arm.tgz
+ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux.tgz
+ENV ALFRESCO_PDF_RENDERER_ARM64_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux-arm.tgz
 
 ENV JAVA_OPTS=""
 

--- a/engines/aio/pom.xml
+++ b/engines/aio/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/base/pom.xml
+++ b/engines/base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/example/Dockerfile
+++ b/engines/example/Dockerfile
@@ -2,7 +2,7 @@ FROM alfresco/alfresco-base-java:jre17-rockylinux8-202302221525
 
 ARG EXIFTOOL_VERSION=12.25
 ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}
-ARG EXIFTOOL_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/exiftool/image-exiftool/${EXIFTOOL_VERSION}/image-exiftool-${EXIFTOOL_VERSION}.tgz
+ARG EXIFTOOL_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/exiftool/image-exiftool/${EXIFTOOL_VERSION}/image-exiftool-${EXIFTOOL_VERSION}.tgz
 
 ENV JAVA_OPTS=""
 

--- a/engines/example/pom.xml
+++ b/engines/example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/imagemagick/Dockerfile
+++ b/engines/imagemagick/Dockerfile
@@ -7,7 +7,7 @@ FROM alfresco/alfresco-base-java:jre17-rockylinux8-202306121108
 # For other ImageMagick versions please look at https://github.com/Alfresco/imagemagick-build tags
 ARG IMAGEMAGICK_VERSION=7.1.0-16
 
-ENV IMAGEMAGICK_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}-ci-3/imagemagick-distribution-${IMAGEMAGICK_VERSION}-ci-3
+ENV IMAGEMAGICK_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/imagemagick/imagemagick-distribution/${IMAGEMAGICK_VERSION}-ci-3/imagemagick-distribution-${IMAGEMAGICK_VERSION}-ci-3
 ENV IMAGEMAGICK_DEP_RPM_URL=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 ENV JAVA_OPTS=""
 

--- a/engines/imagemagick/pom.xml
+++ b/engines/imagemagick/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/libreoffice/Dockerfile
+++ b/engines/libreoffice/Dockerfile
@@ -6,7 +6,7 @@ FROM alfresco/alfresco-base-java:jre17-rockylinux8-202306121108
 
 ARG LIBREOFFICE_VERSION=7.2.5
 
-ENV LIBREOFFICE_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/libreoffice/libreoffice-dist/${LIBREOFFICE_VERSION}/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz
+ENV LIBREOFFICE_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/libreoffice/libreoffice-dist/${LIBREOFFICE_VERSION}/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz
 ENV LIBREOFFICE_ARM64_RPM_URL=https://dl.rockylinux.org/pub/rocky/8/Devel/aarch64/os/Packages/l/
 ENV LIBREOFFICE_ARM64_RPM_VERSION=libreoffice-6.4.7.2
 ENV JAVA_OPTS=""

--- a/engines/libreoffice/pom.xml
+++ b/engines/libreoffice/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/misc/pom.xml
+++ b/engines/misc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/pdfrenderer/Dockerfile
+++ b/engines/pdfrenderer/Dockerfile
@@ -5,8 +5,8 @@
 FROM alfresco/alfresco-base-java:jre17-rockylinux8-202306121108
 
 ARG PDF_RENDERER_VERSION=1.2
-ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux.tgz
-ENV ALFRESCO_PDF_RENDERER_ARM64_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux-arm.tgz
+ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux.tgz
+ENV ALFRESCO_PDF_RENDERER_ARM64_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux-arm.tgz
 ENV JAVA_OPTS=""
 
 # Set default user information

--- a/engines/pdfrenderer/pom.xml
+++ b/engines/pdfrenderer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/tika/Dockerfile
+++ b/engines/tika/Dockerfile
@@ -6,7 +6,7 @@ FROM alfresco/alfresco-base-java:jre17-rockylinux8-202306121108
 
 ARG EXIFTOOL_VERSION=12.25
 ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}
-ARG EXIFTOOL_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/exiftool/image-exiftool/${EXIFTOOL_VERSION}/image-exiftool-${EXIFTOOL_VERSION}.tgz
+ARG EXIFTOOL_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/exiftool/image-exiftool/${EXIFTOOL_VERSION}/image-exiftool-${EXIFTOOL_VERSION}.tgz
 
 ENV JAVA_OPTS=""
 

--- a/engines/tika/pom.xml
+++ b/engines/tika/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>5.1.4-A1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-transform-core</artifactId>
-    <version>5.1.4-SNAPSHOT</version>
+    <version>5.1.4-A1-SNAPSHOT</version>
     <name>Alfresco Transform Core</name>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
As per title. My best guess is that this is required to make the Transform Aspose Spring Boot migration happen, as the previous version of Transform Core & Service that are used there are still using the older Spring Boot version, causing library conflict issues!