### PR TITLE
[MNT-24887]-ATS-Extracting-Photoshop-Urgency-Metadata-Property-Name

### DIFF
--- a/engines/tika/src/main/resources/IPTCMetadataExtractor_metadata_extract.properties
+++ b/engines/tika/src/main/resources/IPTCMetadataExtractor_metadata_extract.properties
@@ -76,7 +76,7 @@ XMP-photoshop\:Source=photoshop:Source
 XMP-photoshop\:State=photoshop:State
 XMP-photoshop\:SupplementalCategories=photoshop:SupplementalCategories
 XMP-photoshop\:TransmissionReference=photoshop:TransmissionReference
-XMP-photoshop\:Urgency=photoshop:Urgency 
+XMP-photoshop\:Urgency=photoshop:Urgency
 XMP-xmpRights\:UsageTerms=xmpRights:UsageTerms
 
 XMP-iptcExt\:AdditionalModelInformation=Iptc4xmpExt:AddlModelInfo


### PR DESCRIPTION

Extracting the Photoshop Urgency metadata adds a photoshop:UrgencyÂ property to ACS. This incorrect name is caused by the space character at the end of the property. Removing the space to correct to photoshop:Urgency. 