### PR TITLE
MNT 24883 saving doc file with original filename

### DIFF
--- a/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
@@ -91,14 +91,22 @@ public class FileManager
 
     private static File createFileFromRequest(HttpServletRequest request, String extension) throws Exception
     {
-        String submittedFileName = request.getParts().stream()
-                .filter(part -> part instanceof MultipartFile && StringUtils.isNotEmpty(part.getSubmittedFileName()))
-                .map(Part::getSubmittedFileName)
-                .findFirst()
-                .orElse(null);
-        return StringUtils.isNotEmpty(submittedFileName)
-                ? TempFileProvider.createFileWithinUUIDTempDir(submittedFileName)
-                : TempFileProvider.createTempFile("source_", extension);
+        try
+        {
+            String submittedFileName = request.getParts().stream()
+                    .filter(part -> part instanceof MultipartFile && StringUtils.isNotEmpty(part.getSubmittedFileName()))
+                    .map(Part::getSubmittedFileName)
+                    .findFirst()
+                    .orElse(null);
+            return StringUtils.isNotEmpty(submittedFileName)
+                    ? TempFileProvider.createFileWithinUUIDTempDir(submittedFileName)
+                    : TempFileProvider.createTempFile("source_", extension);
+        }
+        catch (Exception e)
+        {
+            throw new TransformException(INTERNAL_SERVER_ERROR, "Failed to create source file from request", e);
+        }
+
     }
 
     public static File createSourceFileUsingOriginalFileName(String sourceFileName, InputStream inputStream, String sourceMimetype)

--- a/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
@@ -89,7 +89,7 @@ public class FileManager
         }
     }
 
-    private static File createFileFromRequest(HttpServletRequest request, String extension) throws Exception
+    private static File createFileFromRequest(HttpServletRequest request, String extension)
     {
         try
         {

--- a/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
@@ -55,7 +55,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriUtils;
 
 import org.alfresco.transform.base.logging.LogEntry;
-import org.alfresco.transform.base.util.Util;
 import org.alfresco.transform.common.ExtensionService;
 import org.alfresco.transform.exceptions.TransformException;
 
@@ -81,7 +80,7 @@ public class FileManager
                         .map(Part::getSubmittedFileName)
                         .findFirst()
                         .orElse(null);
-                file = (!StringUtils.isEmpty(submittedFileName) && Util.isDocFile(submittedFileName))
+                file = !StringUtils.isEmpty(submittedFileName)
                         ? TempFileProvider.createTempDirForDocFile(submittedFileName)
                         : TempFileProvider.createTempFile("source_", extension);
             }
@@ -103,16 +102,12 @@ public class FileManager
         }
     }
 
-    public static File createSourceDocFileWithSameName(HttpServletRequest request, String sourceFileName, InputStream inputStream, String sourceMimetype)
+    public static File createSourceDocFileWithSameName(String sourceFileName, InputStream inputStream)
     {
         try
         {
             File file = TempFileProvider.createTempDirForDocFile(sourceFileName);
             Files.copy(inputStream, file.toPath(), REPLACE_EXISTING);
-            if (request != null)
-            {
-                request.setAttribute(SOURCE_FILE, file);
-            }
             LogEntry.setSource(file.getName(), file.length());
             return file;
         }

--- a/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
@@ -43,6 +43,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.Objects;
 import java.util.UUID;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.Part;
@@ -94,9 +95,9 @@ public class FileManager
         try
         {
             String submittedFileName = request.getParts().stream()
-                    .filter(part -> part instanceof MultipartFile && StringUtils.isNotEmpty(part.getSubmittedFileName()))
+                    .filter(part -> Objects.nonNull(part) && StringUtils.isNotEmpty(part.getSubmittedFileName()))
                     .map(Part::getSubmittedFileName)
-                    .findFirst()
+                    .findAny()
                     .orElse(null);
             return StringUtils.isNotEmpty(submittedFileName)
                     ? TempFileProvider.createFileWithinUUIDTempDir(submittedFileName)

--- a/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
@@ -77,6 +77,7 @@ public class FileManager
             if (request != null && request.getParts() != null)
             {
                 String submittedFileName = request.getParts().stream()
+                        .filter(part -> part instanceof MultipartFile && StringUtils.isNotEmpty(part.getSubmittedFileName()))
                         .map(Part::getSubmittedFileName)
                         .findFirst()
                         .orElse(null);

--- a/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
@@ -120,7 +120,6 @@ public class FileManager
         {
             throw new TransformException(INSUFFICIENT_STORAGE, "Failed to store the source file", e);
         }
-
     }
 
     public static File createTargetFile(HttpServletRequest request, String sourceMimetype, String targetMimetype)
@@ -263,21 +262,12 @@ public class FileManager
 
         public static File createTempDirForDocFile(String sourceFileName)
         {
-            final File alfrescoTempDirectory = getTempDir();
-            try
+            File tempDir = new File(getTempDir(), UUID.randomUUID().toString());
+            if (!tempDir.mkdirs() && !tempDir.exists())
             {
-                UUID uuid = UUID.randomUUID();
-                final File tempDir = new File(alfrescoTempDirectory, uuid.toString());
-                if (!tempDir.exists() && !tempDir.mkdirs() && !tempDir.exists())
-                {
-                    throw new RuntimeException("Failed to create temp directory: " + tempDir);
-                }
-                return new File(tempDir, sourceFileName);
+                throw new TransformException(INSUFFICIENT_STORAGE, "Failed to create temp directory: " + tempDir);
             }
-            catch (Exception e)
-            {
-                throw new RuntimeException("Failed to created temp file: \n   file: " + sourceFileName + "\n", e);
-            }
+            return new File(tempDir, sourceFileName);
         }
 
         private static File getTempDir()

--- a/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/fs/FileManager.java
@@ -28,8 +28,10 @@ package org.alfresco.transform.base.fs;
 
 import jakarta.servlet.http.Part;
 import org.alfresco.transform.base.logging.LogEntry;
+import org.alfresco.transform.base.util.Util;
 import org.alfresco.transform.common.ExtensionService;
 import org.alfresco.transform.exceptions.TransformException;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.http.ResponseEntity;
@@ -73,10 +75,9 @@ public class FileManager
             if (request != null && request.getParts() != null) {
                 String submittedFileName = request.getParts().stream()
                         .map(Part::getSubmittedFileName)
-                        .filter(name -> name != null && extension.contains(".doc"))
                         .findFirst()
                         .orElse(null);
-                file = (submittedFileName != null)
+                file = (!StringUtils.isEmpty(submittedFileName) && Util.isDocFile(submittedFileName))
                         ? TempFileProvider.createTempDirForDocFile(submittedFileName)
                         : TempFileProvider.createTempFile("source_", extension);
             }
@@ -99,8 +100,7 @@ public class FileManager
     }
 
 
-    public static File createSourceFileWithSameName(HttpServletRequest request, String sourceFileName, InputStream inputStream, String sourceMimetype) {
-
+    public static File createSourceDocFileWithSameName(HttpServletRequest request, String sourceFileName, InputStream inputStream, String sourceMimetype) {
         try
         {
             File file = TempFileProvider.createTempDirForDocFile(sourceFileName);
@@ -269,8 +269,6 @@ public class FileManager
                     throw new RuntimeException("Failed to create temp directory: " + tempDir);
                 }
                 return new File(tempDir, sourceFileName);
-//                return File.createTempFile(sourceFileName, ".docx", tempDir);
-//                return File.createTempFile(sourceFileName, ".docx", alfrescoTempDirectory);
             }
             catch (Exception e)
             {

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/ProcessHandler.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/ProcessHandler.java
@@ -68,6 +68,7 @@ abstract class ProcessHandler extends FragmentHandler
     private static final List<String> NON_TRANSFORM_OPTION_REQUEST_PARAMETERS = Arrays.asList(SOURCE_EXTENSION,
         TARGET_EXTENSION, TARGET_MIMETYPE, SOURCE_MIMETYPE, DIRECT_ACCESS_URL);
 
+    protected String sourceFileName=null;
     protected final String sourceMimetype;
     protected final String targetMimetype;
     private final Map<String, String> transformOptions;
@@ -81,6 +82,22 @@ abstract class ProcessHandler extends FragmentHandler
         String reference, TransformServiceRegistry transformRegistry, TransformerDebug transformerDebug,
         ProbeTransform probeTransform, CustomTransformers customTransformers)
     {
+        this.sourceMimetype = sourceMimetype;
+        this.targetMimetype = targetMimetype;
+        this.transformOptions = cleanTransformOptions(transformOptions);
+        this.reference = reference;
+
+        this.transformRegistry = transformRegistry;
+        this.transformerDebug = transformerDebug;
+        this.probeTransform = probeTransform;
+        this.customTransformers = customTransformers;
+    }
+
+    ProcessHandler(String sourceFileName,String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
+                   String reference, TransformServiceRegistry transformRegistry, TransformerDebug transformerDebug,
+                   ProbeTransform probeTransform, CustomTransformers customTransformers)
+    {
+        this.sourceFileName = sourceFileName;
         this.sourceMimetype = sourceMimetype;
         this.targetMimetype = targetMimetype;
         this.transformOptions = cleanTransformOptions(transformOptions);

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/ProcessHandler.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/ProcessHandler.java
@@ -68,7 +68,6 @@ abstract class ProcessHandler extends FragmentHandler
     private static final List<String> NON_TRANSFORM_OPTION_REQUEST_PARAMETERS = Arrays.asList(SOURCE_EXTENSION,
         TARGET_EXTENSION, TARGET_MIMETYPE, SOURCE_MIMETYPE, DIRECT_ACCESS_URL);
 
-    protected String sourceFileName=null;
     protected final String sourceMimetype;
     protected final String targetMimetype;
     private final Map<String, String> transformOptions;
@@ -82,22 +81,6 @@ abstract class ProcessHandler extends FragmentHandler
         String reference, TransformServiceRegistry transformRegistry, TransformerDebug transformerDebug,
         ProbeTransform probeTransform, CustomTransformers customTransformers)
     {
-        this.sourceMimetype = sourceMimetype;
-        this.targetMimetype = targetMimetype;
-        this.transformOptions = cleanTransformOptions(transformOptions);
-        this.reference = reference;
-
-        this.transformRegistry = transformRegistry;
-        this.transformerDebug = transformerDebug;
-        this.probeTransform = probeTransform;
-        this.customTransformers = customTransformers;
-    }
-
-    ProcessHandler(String sourceFileName,String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
-                   String reference, TransformServiceRegistry transformRegistry, TransformerDebug transformerDebug,
-                   ProbeTransform probeTransform, CustomTransformers customTransformers)
-    {
-        this.sourceFileName = sourceFileName;
         this.sourceMimetype = sourceMimetype;
         this.targetMimetype = targetMimetype;
         this.transformOptions = cleanTransformOptions(transformOptions);

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformHandler.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformHandler.java
@@ -26,6 +26,7 @@
  */
 package org.alfresco.transform.base.transform;
 
+import org.alfresco.transform.base.TransformManager;
 import org.alfresco.transform.base.sfs.SharedFileStoreClient;
 import org.alfresco.transform.base.messaging.TransformReplySender;
 import org.alfresco.transform.base.model.FileRefResponse;
@@ -101,6 +102,8 @@ public class TransformHandler
     private TransformerDebug transformerDebug;
 
     private final AtomicInteger httpRequestCount = new AtomicInteger(1);
+    @Autowired
+    private TransformManager transformManager;
 
     public ResponseEntity<Resource> handleHttpRequest(HttpServletRequest request,
             MultipartFile sourceMultipartFile, String sourceMimetype, String targetMimetype,
@@ -190,7 +193,7 @@ public class TransformHandler
         ProbeTransform probeTransform)
     {
         TransformReply reply = createBasicTransformReply(request);
-        new ProcessHandler(request.getSourceFileName(),request.getSourceMediaType(), request.getTargetMediaType(),
+        new ProcessHandler(request.getSourceMediaType(), request.getTargetMediaType(),
             request.getTransformRequestOptions(),"unset", transformRegistry,
             transformerDebug, probeTransform, customTransformers)
         {
@@ -199,6 +202,7 @@ public class TransformHandler
             {
                 checkTransformRequestValid(request, reply);
                 reference = TransformStack.getReference(reply.getInternalContext());
+                transformManager.setSourceFileName(request.getSourceFileName());
                 initTarget();
                 super.init();
             }

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformHandler.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformHandler.java
@@ -26,35 +26,18 @@
  */
 package org.alfresco.transform.base.transform;
 
-import org.alfresco.transform.base.TransformManager;
-import org.alfresco.transform.base.sfs.SharedFileStoreClient;
-import org.alfresco.transform.base.messaging.TransformReplySender;
-import org.alfresco.transform.base.model.FileRefResponse;
-import org.alfresco.transform.base.probes.ProbeTransform;
-import org.alfresco.transform.base.registry.CustomTransformers;
-import org.alfresco.transform.client.model.InternalContext;
-import org.alfresco.transform.client.model.TransformReply;
-import org.alfresco.transform.client.model.TransformRequest;
-import org.alfresco.transform.common.ExtensionService;
-import org.alfresco.transform.exceptions.TransformException;
-import org.alfresco.transform.common.TransformerDebug;
-import org.alfresco.transform.messages.TransformRequestValidator;
-import org.alfresco.transform.messages.TransformStack;
-import org.alfresco.transform.registry.TransformServiceRegistry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.Resource;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
-import org.springframework.validation.DirectFieldBindingResult;
-import org.springframework.validation.Errors;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.multipart.MultipartFile;
+import static java.util.stream.Collectors.joining;
 
-import jakarta.jms.Destination;
-import jakarta.servlet.http.HttpServletRequest;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import static org.alfresco.transform.base.fs.FileManager.createAttachment;
+import static org.alfresco.transform.base.fs.FileManager.createTargetFile;
+import static org.alfresco.transform.base.fs.FileManager.getDirectAccessUrlInputStream;
+import static org.alfresco.transform.base.fs.FileManager.getMultipartFileInputStream;
+import static org.alfresco.transform.common.RequestParamMap.DIRECT_ACCESS_URL;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -67,16 +50,35 @@ import java.io.OutputStream;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import jakarta.jms.Destination;
+import jakarta.servlet.http.HttpServletRequest;
 
-import static java.util.stream.Collectors.joining;
-import static org.alfresco.transform.base.fs.FileManager.createAttachment;
-import static org.alfresco.transform.base.fs.FileManager.createTargetFile;
-import static org.alfresco.transform.base.fs.FileManager.getDirectAccessUrlInputStream;
-import static org.alfresco.transform.base.fs.FileManager.getMultipartFileInputStream;
-import static org.alfresco.transform.common.RequestParamMap.DIRECT_ACCESS_URL;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.DirectFieldBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.multipart.MultipartFile;
+
+import org.alfresco.transform.base.messaging.TransformReplySender;
+import org.alfresco.transform.base.model.FileRefResponse;
+import org.alfresco.transform.base.probes.ProbeTransform;
+import org.alfresco.transform.base.registry.CustomTransformers;
+import org.alfresco.transform.base.sfs.SharedFileStoreClient;
+import org.alfresco.transform.client.model.InternalContext;
+import org.alfresco.transform.client.model.TransformReply;
+import org.alfresco.transform.client.model.TransformRequest;
+import org.alfresco.transform.common.ExtensionService;
+import org.alfresco.transform.common.TransformerDebug;
+import org.alfresco.transform.exceptions.TransformException;
+import org.alfresco.transform.messages.TransformRequestValidator;
+import org.alfresco.transform.messages.TransformStack;
+import org.alfresco.transform.registry.TransformServiceRegistry;
 
 /**
  * Handles the transform requests from either http or a message.
@@ -102,8 +104,6 @@ public class TransformHandler
     private TransformerDebug transformerDebug;
 
     private final AtomicInteger httpRequestCount = new AtomicInteger(1);
-    @Autowired
-    private TransformManager transformManager;
 
     public ResponseEntity<Resource> handleHttpRequest(HttpServletRequest request,
             MultipartFile sourceMultipartFile, String sourceMimetype, String targetMimetype,
@@ -112,9 +112,8 @@ public class TransformHandler
         AtomicReference<ResponseEntity<Resource>> responseEntity = new AtomicReference<>();
 
         new ProcessHandler(sourceMimetype, targetMimetype, requestParameters,
-            "e" + httpRequestCount.getAndIncrement(), transformRegistry,
-            transformerDebug, probeTransform, customTransformers)
-        {
+                "e" + httpRequestCount.getAndIncrement(), transformRegistry,
+                transformerDebug, probeTransform, customTransformers) {
             @Override
             protected void init() throws IOException
             {
@@ -146,7 +145,7 @@ public class TransformHandler
             protected void sendTransformResponse(TransformManagerImpl transformManager)
             {
                 String extension = ExtensionService.getExtensionForTargetMimetype(targetMimetype, sourceMimetype);
-                responseEntity.set(createAttachment("transform."+extension, transformManager.getTargetFile()));
+                responseEntity.set(createAttachment("transform." + extension, transformManager.getTargetFile()));
             }
         }.handleTransformRequest();
 
@@ -154,12 +153,11 @@ public class TransformHandler
     }
 
     public void handleProbeRequest(String sourceMimetype, String targetMimetype, Map<String, String> transformOptions,
-        File sourceFile, File targetFile, ProbeTransform probeTransform)
+            File sourceFile, File targetFile, ProbeTransform probeTransform)
     {
         new ProcessHandler(sourceMimetype, targetMimetype, transformOptions,
-            "p" + httpRequestCount.getAndIncrement(), transformRegistry,
-            transformerDebug, probeTransform, customTransformers)
-        {
+                "p" + httpRequestCount.getAndIncrement(), transformRegistry,
+                transformerDebug, probeTransform, customTransformers) {
             @Override
             protected void init() throws IOException
             {
@@ -190,13 +188,12 @@ public class TransformHandler
     }
 
     public TransformReply handleMessageRequest(TransformRequest request, Long timeout, Destination replyToQueue,
-        ProbeTransform probeTransform)
+            ProbeTransform probeTransform)
     {
         TransformReply reply = createBasicTransformReply(request);
         new ProcessHandler(request.getSourceMediaType(), request.getTargetMediaType(),
-            request.getTransformRequestOptions(),"unset", transformRegistry,
-            transformerDebug, probeTransform, customTransformers)
-        {
+                request.getTransformRequestOptions(), "unset", transformRegistry,
+                transformerDebug, probeTransform, customTransformers) {
             @Override
             protected void init() throws IOException
             {
@@ -341,12 +338,12 @@ public class TransformHandler
     }
 
     private InputStream getInputStreamForHandleHttpRequest(Map<String, String> requestParameters,
-        MultipartFile sourceMultipartFile)
+            MultipartFile sourceMultipartFile)
     {
         final String directUrl = requestParameters.getOrDefault(DIRECT_ACCESS_URL, "");
         return new BufferedInputStream(directUrl.isBlank()
-            ? getMultipartFileInputStream(sourceMultipartFile)
-            : getDirectAccessUrlInputStream(directUrl));
+                ? getMultipartFileInputStream(sourceMultipartFile)
+                : getDirectAccessUrlInputStream(directUrl));
     }
 
     private InputStream getInputStreamForHandleProbeRequest(File sourceFile)
@@ -423,8 +420,8 @@ public class TransformHandler
         {
             e = e.getCause();
             sb.append(", cause ")
-              .append(e.getClass().getSimpleName()).append(": ")
-              .append(e.getMessage());
+                    .append(e.getClass().getSimpleName()).append(": ")
+                    .append(e.getMessage());
         }
 
         return sb.toString();

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformHandler.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformHandler.java
@@ -190,7 +190,7 @@ public class TransformHandler
         ProbeTransform probeTransform)
     {
         TransformReply reply = createBasicTransformReply(request);
-        new ProcessHandler(request.getSourceMediaType(), request.getTargetMediaType(),
+        new ProcessHandler(request.getSourceFileName(),request.getSourceMediaType(), request.getTargetMediaType(),
             request.getTransformRequestOptions(),"unset", transformRegistry,
             transformerDebug, probeTransform, customTransformers)
         {

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -176,9 +176,7 @@ public class TransformManagerImpl implements TransformManager
 
         if (sourceFile == null)
         {
-            sourceFile = request == null
-                    ? FileManager.createSourceFileUsingOriginalFileName(sourceFileName, inputStream, sourceMimetype)
-                    : FileManager.createSourceFile(request, inputStream, sourceMimetype);
+            sourceFile = FileManager.createSourceFile(request, inputStream, sourceMimetype, sourceFileName);
         }
         return sourceFile;
     }

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -26,20 +26,21 @@
  */
 package org.alfresco.transform.base.transform;
 
-import org.alfresco.transform.base.TransformManager;
-import org.alfresco.transform.base.fs.FileManager;
-import org.alfresco.transform.base.util.OutputStreamLengthRecorder;
-import org.alfresco.transform.base.util.Util;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import jakarta.servlet.http.HttpServletRequest;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import org.alfresco.transform.base.TransformManager;
+import org.alfresco.transform.base.fs.FileManager;
+import org.alfresco.transform.base.util.OutputStreamLengthRecorder;
+import org.alfresco.transform.base.util.Util;
 
 /**
  * Manages the input and output streams and any temporary files that have been created.
@@ -75,7 +76,8 @@ public class TransformManagerImpl implements TransformManager
         this.processHandler = processHandler;
     }
 
-    @Override public String getRequestId()
+    @Override
+    public String getRequestId()
     {
         return processHandler.getReference();
     }
@@ -163,8 +165,8 @@ public class TransformManagerImpl implements TransformManager
         this.sourceFileName = sourceFileName;
     }
 
-
-    @Override public File createSourceFile()
+    @Override
+    public File createSourceFile()
     {
         if (createSourceFileCalled)
         {
@@ -182,7 +184,8 @@ public class TransformManagerImpl implements TransformManager
         return sourceFile;
     }
 
-    @Override public File createTargetFile()
+    @Override
+    public File createTargetFile()
     {
         if (createTargetFileCalled)
         {
@@ -229,13 +232,17 @@ public class TransformManagerImpl implements TransformManager
         startedWithSourceFile = null;
     }
 
-    public void deleteDocUUIDFolder() {
-        if (sourceFile == null) return;
-        if(Util.isDocFile(sourceFile.getPath())) {
+    public void deleteDocUUIDFolder()
+    {
+        if (sourceFile == null)
+            return;
+        if (Util.isDocFile(sourceFile.getPath()))
+        {
             File parentDir = sourceFile.getParentFile();
             if (parentDir != null
-                    && !StringUtils.equalsAny(parentDir.getName().toLowerCase(), "alfresco","temp","tmp")
-                    && !parentDir.delete()) {
+                    && !StringUtils.equalsAny(parentDir.getName().toLowerCase(), "alfresco", "temp", "tmp")
+                    && !parentDir.delete())
+            {
                 logger.error("Failed to delete parent directory {}", parentDir.getPath());
             }
         }

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -54,7 +54,6 @@ public class TransformManagerImpl implements TransformManager
     private OutputStreamLengthRecorder outputStreamLengthRecorder;
     private String sourceMimetype;
     private String targetMimetype;
-    private String sourceFileName;
     private File sourceFile;
     private File targetFile;
     private boolean keepTargetFile;
@@ -160,9 +159,9 @@ public class TransformManagerImpl implements TransformManager
         createSourceFileCalled = true;
 
         if (sourceFile == null) {
-            sourceFile = StringUtils.isEmpty(sourceFileName)
+            sourceFile = StringUtils.isEmpty(this.processHandler.sourceFileName)
                     ? FileManager.createSourceFile(request, inputStream, sourceMimetype)
-                    : FileManager.createSourceFileWithSameName(request, sourceFileName, inputStream, sourceMimetype);
+                    : FileManager.createSourceFileWithSameName(request, this.processHandler.sourceFileName, inputStream, sourceMimetype);
         }
         return sourceFile;
     }

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -228,6 +228,7 @@ public class TransformManagerImpl implements TransformManager
         deleteDocUUIDFolder();
         outputStreamLengthRecorder = null;
         sourceFile = null;
+        sourceFileName = null;
         createSourceFileCalled = false;
         startedWithSourceFile = null;
     }

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -59,7 +59,6 @@ public class TransformManagerImpl implements TransformManager
     private String targetMimetype;
     private File sourceFile;
     private File targetFile;
-
     private boolean keepTargetFile;
     private boolean createSourceFileCalled;
     private boolean createTargetFileCalled;

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -222,10 +222,23 @@ public class TransformManagerImpl implements TransformManager
         {
             logger.error("Failed to delete temporary source file {}", sourceFile.getPath());
         }
+        deleteDocUUIDFolder();
         outputStreamLengthRecorder = null;
         sourceFile = null;
         createSourceFileCalled = false;
         startedWithSourceFile = null;
+    }
+
+    public void deleteDocUUIDFolder() {
+        if (sourceFile == null) return;
+        if(Util.isDocFile(sourceFile.getPath())) {
+            File parentDir = sourceFile.getParentFile();
+            if (parentDir != null
+                    && !StringUtils.equalsAny(parentDir.getName().toLowerCase(), "alfresco","temp","tmp")
+                    && !parentDir.delete()) {
+                logger.error("Failed to delete parent directory {}", parentDir.getPath());
+            }
+        }
     }
 
     public void deleteTargetFile()

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -41,7 +41,6 @@ import org.springframework.stereotype.Component;
 import org.alfresco.transform.base.TransformManager;
 import org.alfresco.transform.base.fs.FileManager;
 import org.alfresco.transform.base.util.OutputStreamLengthRecorder;
-import org.alfresco.transform.base.util.Util;
 
 /**
  * Manages the input and output streams and any temporary files that have been created.
@@ -177,9 +176,8 @@ public class TransformManagerImpl implements TransformManager
 
         if (sourceFile == null)
         {
-            boolean isDocFile = !StringUtils.isEmpty(this.sourceFileName) && Util.isDocFile(this.sourceFileName);
-            sourceFile = isDocFile
-                    ? FileManager.createSourceDocFileWithSameName(request, this.sourceFileName, inputStream, sourceMimetype)
+            sourceFile = request == null
+                    ? FileManager.createSourceDocFileWithSameName(sourceFileName, inputStream)
                     : FileManager.createSourceFile(request, inputStream, sourceMimetype);
         }
         return sourceFile;
@@ -226,7 +224,7 @@ public class TransformManagerImpl implements TransformManager
         {
             logger.error("Failed to delete temporary source file {}", sourceFile.getPath());
         }
-        if (sourceFile != null && Util.isDocFile(sourceFile.getPath()))
+        if (sourceFile != null)
         {
             File parentDir = sourceFile.getParentFile();
             if (parentDir != null

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -225,21 +225,7 @@ public class TransformManagerImpl implements TransformManager
         {
             logger.error("Failed to delete temporary source file {}", sourceFile.getPath());
         }
-        deleteDocUUIDFolder();
-        outputStreamLengthRecorder = null;
-        sourceFile = null;
-        sourceFileName = null;
-        createSourceFileCalled = false;
-        startedWithSourceFile = null;
-    }
-
-    public void deleteDocUUIDFolder()
-    {
-        if (sourceFile == null)
-        {
-            return;
-        }
-        if (Util.isDocFile(sourceFile.getPath()))
+        if (sourceFile != null && Util.isDocFile(sourceFile.getPath()))
         {
             File parentDir = sourceFile.getParentFile();
             if (parentDir != null
@@ -249,6 +235,11 @@ public class TransformManagerImpl implements TransformManager
                 logger.error("Failed to delete parent directory {}", parentDir.getPath());
             }
         }
+        outputStreamLengthRecorder = null;
+        sourceFile = null;
+        sourceFileName = null;
+        createSourceFileCalled = false;
+        startedWithSourceFile = null;
     }
 
     public void deleteTargetFile()

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -46,6 +46,7 @@ import org.alfresco.transform.base.util.Util;
 /**
  * Manages the input and output streams and any temporary files that have been created.
  */
+@SuppressWarnings("PMD.GodClass")
 @Component
 public class TransformManagerImpl implements TransformManager
 {

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -177,7 +177,7 @@ public class TransformManagerImpl implements TransformManager
         if (sourceFile == null)
         {
             sourceFile = request == null
-                    ? FileManager.createSourceDocFileWithSameName(sourceFileName, inputStream)
+                    ? FileManager.createSourceFileUsingOriginalFileName(sourceFileName, inputStream, sourceMimetype)
                     : FileManager.createSourceFile(request, inputStream, sourceMimetype);
         }
         return sourceFile;

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Locale;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
@@ -236,12 +237,14 @@ public class TransformManagerImpl implements TransformManager
     public void deleteDocUUIDFolder()
     {
         if (sourceFile == null)
+        {
             return;
+        }
         if (Util.isDocFile(sourceFile.getPath()))
         {
             File parentDir = sourceFile.getParentFile();
             if (parentDir != null
-                    && !StringUtils.equalsAny(parentDir.getName().toLowerCase(), "alfresco", "temp", "tmp")
+                    && !StringUtils.equalsAny(parentDir.getName().toLowerCase(Locale.ROOT), "alfresco", "temp", "tmp")
                     && !parentDir.delete())
             {
                 logger.error("Failed to delete parent directory {}", parentDir.getPath());

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -29,6 +29,7 @@ package org.alfresco.transform.base.transform;
 import org.alfresco.transform.base.TransformManager;
 import org.alfresco.transform.base.fs.FileManager;
 import org.alfresco.transform.base.util.OutputStreamLengthRecorder;
+import org.alfresco.transform.base.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,11 +57,13 @@ public class TransformManagerImpl implements TransformManager
     private String targetMimetype;
     private File sourceFile;
     private File targetFile;
+
     private boolean keepTargetFile;
     private boolean createSourceFileCalled;
     private boolean createTargetFileCalled;
     private Boolean startedWithSourceFile;
     private Boolean startedWithTargetFile;
+    private String sourceFileName;
 
     public void setRequest(HttpServletRequest request)
     {
@@ -150,6 +153,17 @@ public class TransformManagerImpl implements TransformManager
         keepTargetFile = true;
     }
 
+    public String getSourceFileName()
+    {
+        return sourceFileName;
+    }
+
+    public void setSourceFileName(String sourceFileName)
+    {
+        this.sourceFileName = sourceFileName;
+    }
+
+
     @Override public File createSourceFile()
     {
         if (createSourceFileCalled)
@@ -158,10 +172,12 @@ public class TransformManagerImpl implements TransformManager
         }
         createSourceFileCalled = true;
 
-        if (sourceFile == null) {
-            sourceFile = StringUtils.isEmpty(this.processHandler.sourceFileName)
-                    ? FileManager.createSourceFile(request, inputStream, sourceMimetype)
-                    : FileManager.createSourceFileWithSameName(request, this.processHandler.sourceFileName, inputStream, sourceMimetype);
+        if (sourceFile == null)
+        {
+            boolean isDocFile = !StringUtils.isEmpty(this.sourceFileName) && Util.isDocFile(this.sourceFileName);
+            sourceFile = isDocFile
+                    ? FileManager.createSourceDocFileWithSameName(request, this.sourceFileName, inputStream, sourceMimetype)
+                    : FileManager.createSourceFile(request, inputStream, sourceMimetype);
         }
         return sourceFile;
     }

--- a/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/transform/TransformManagerImpl.java
@@ -29,6 +29,7 @@ package org.alfresco.transform.base.transform;
 import org.alfresco.transform.base.TransformManager;
 import org.alfresco.transform.base.fs.FileManager;
 import org.alfresco.transform.base.util.OutputStreamLengthRecorder;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -53,6 +54,7 @@ public class TransformManagerImpl implements TransformManager
     private OutputStreamLengthRecorder outputStreamLengthRecorder;
     private String sourceMimetype;
     private String targetMimetype;
+    private String sourceFileName;
     private File sourceFile;
     private File targetFile;
     private boolean keepTargetFile;
@@ -157,9 +159,10 @@ public class TransformManagerImpl implements TransformManager
         }
         createSourceFileCalled = true;
 
-        if (sourceFile == null)
-        {
-            sourceFile = FileManager.createSourceFile(request, inputStream, sourceMimetype);
+        if (sourceFile == null) {
+            sourceFile = StringUtils.isEmpty(sourceFileName)
+                    ? FileManager.createSourceFile(request, inputStream, sourceMimetype)
+                    : FileManager.createSourceFileWithSameName(request, sourceFileName, inputStream, sourceMimetype);
         }
         return sourceFile;
     }

--- a/engines/base/src/main/java/org/alfresco/transform/base/util/Util.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/util/Util.java
@@ -64,4 +64,15 @@ public class Util
     {
         return param == null ? null : Long.parseLong(param);
     }
+
+    /**
+     * check if given file name is a doc file
+     * @param filename
+     * @return if file is .doc*
+     */
+    public static boolean isDocFile(String filename)
+    {
+        String extension = filename.substring(filename.lastIndexOf('.') );
+        return extension.startsWith(".doc");
+    }
 }

--- a/engines/base/src/main/java/org/alfresco/transform/base/util/Util.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/util/Util.java
@@ -66,16 +66,4 @@ public class Util
     {
         return param == null ? null : Long.parseLong(param);
     }
-
-    /**
-     * check if given file name is a doc file
-     * 
-     * @param filename
-     * @return if file is .doc*
-     */
-    public static boolean isDocFile(String filename)
-    {
-        String extension = filename.substring(filename.lastIndexOf('.'));
-        return extension.startsWith(".doc");
-    }
 }

--- a/engines/base/src/main/java/org/alfresco/transform/base/util/Util.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/util/Util.java
@@ -29,13 +29,13 @@ package org.alfresco.transform.base.util;
 public class Util
 {
     private Util()
-    {
-    }
+    {}
 
     /**
      * Safely converts a {@link String} to an {@link Integer}
      *
-     * @param param String to be converted
+     * @param param
+     *            String to be converted
      * @return Null if param is null or converted value as {@link Integer}
      */
     public static Integer stringToInteger(final String param)
@@ -46,7 +46,8 @@ public class Util
     /**
      * Safely converts a {@link String} to a {@link Boolean}
      *
-     * @param param String to be converted
+     * @param param
+     *            String to be converted
      * @return Null if param is null or converted value as {@link Boolean}
      */
     public static Boolean stringToBoolean(final String param)
@@ -57,7 +58,8 @@ public class Util
     /**
      * Safely converts a {@link String} to a {@link Long}
      *
-     * @param param String to be converted
+     * @param param
+     *            String to be converted
      * @return Null if param is null or converted value as {@link Boolean}
      */
     public static Long stringToLong(final String param)
@@ -67,12 +69,13 @@ public class Util
 
     /**
      * check if given file name is a doc file
+     * 
      * @param filename
      * @return if file is .doc*
      */
     public static boolean isDocFile(String filename)
     {
-        String extension = filename.substring(filename.lastIndexOf('.') );
+        String extension = filename.substring(filename.lastIndexOf('.'));
         return extension.startsWith(".doc");
     }
 }

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
@@ -26,9 +26,9 @@
  */
 package org.alfresco.transform.base.transform;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.alfresco.transform.base.CustomTransformer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -42,25 +42,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.Part;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
-
-import org.alfresco.transform.base.CustomTransformer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests {@link StreamHandler}, {@link TransformManagerImpl#createSourceFile()} and {@link TransformManagerImpl#createTargetFile()} methods.
+ * Tests {@link StreamHandler}, {@link TransformManagerImpl#createSourceFile()} and
+ * {@link TransformManagerImpl#createTargetFile()} methods.
  */
 public class StreamHandlerTest
 {
     public static final String ORIGINAL = "Original";
     public static final String CHANGE = " plus some change";
-    public static final String EXPECTED = ORIGINAL + CHANGE;
+    public static final String EXPECTED = ORIGINAL+ CHANGE;
 
     TransformManagerImpl transformManager = new TransformManagerImpl();
     @TempDir
@@ -137,12 +132,12 @@ public class StreamHandlerTest
     public void testStartWithInputStream() throws Exception
     {
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -160,14 +155,14 @@ public class StreamHandlerTest
     public void testStartWithInputStreamAndCallCreateSourceFile() throws Exception
     {
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
             File sourceFileCreatedByTransform = transformManager.createSourceFile();
             assertTrue(sourceFileCreatedByTransform.exists());
-            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
+            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -190,12 +185,12 @@ public class StreamHandlerTest
         transformManager.setSourceFile(sourceFile);
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(sourceFile));
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -218,14 +213,14 @@ public class StreamHandlerTest
         transformManager.setSourceFile(sourceFile);
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(sourceFile));
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
             File sourceFileCreatedByTransform = transformManager.createSourceFile();
             assertEquals(sourceFile, sourceFileCreatedByTransform);
-            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
+            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -252,14 +247,14 @@ public class StreamHandlerTest
     public void testStartWithOutputStreamAndCallCreateTargetFile() throws Exception
     {
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             transformManager.setOutputStream(outputStream);
 
             File targetFileCreatedByTransform = transformManager.createTargetFile();
             assertTrue(targetFileCreatedByTransform.exists());
-            write(targetFileCreatedByTransform, read(inputStream) + CHANGE);
+            write(targetFileCreatedByTransform, read(inputStream)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -281,12 +276,12 @@ public class StreamHandlerTest
         transformManager.setTargetFile(targetFile);
 
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -309,14 +304,14 @@ public class StreamHandlerTest
         transformManager.setTargetFile(targetFile);
 
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             transformManager.setOutputStream(outputStream);
 
             File targetFileCreatedByTransform = transformManager.createTargetFile();
             assertEquals(targetFile, targetFileCreatedByTransform);
-            write(targetFileCreatedByTransform, read(inputStream) + CHANGE);
+            write(targetFileCreatedByTransform, read(inputStream)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -349,12 +344,12 @@ public class StreamHandlerTest
         transformManager.keepTargetFile();
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(sourceFile));
-                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -380,12 +375,12 @@ public class StreamHandlerTest
         transformManager.setTargetFile(targetFile);
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(sourceFile));
-                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -409,12 +404,12 @@ public class StreamHandlerTest
         transformManager.setTargetFile(targetFile);
 
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -442,7 +437,7 @@ public class StreamHandlerTest
         @Override
         protected void transform(CustomTransformer customTransformer) throws Exception
         {
-            write(outputStream, read(inputStream) + CHANGE);
+            write(outputStream, read(inputStream)+CHANGE);
         }
     }
 
@@ -453,7 +448,8 @@ public class StreamHandlerTest
 
         try (ByteArrayOutputStream os = new ByteArrayOutputStream())
         {
-            new FakeStreamHandler() {
+            new FakeStreamHandler()
+            {
                 @Override
                 protected void init() throws IOException
                 {
@@ -484,7 +480,8 @@ public class StreamHandlerTest
         File sourceFile = tempFile();
         write(sourceFile, ORIGINAL);
 
-        new FakeStreamHandler() {
+        new FakeStreamHandler()
+        {
             @Override
             protected void init() throws IOException
             {
@@ -515,7 +512,8 @@ public class StreamHandlerTest
         File sourceFile = tempFile();
         write(sourceFile, ORIGINAL);
 
-        new FakeStreamHandler() {
+        new FakeStreamHandler()
+        {
             @Override
             protected InputStream getInputStream() throws IOException
             {
@@ -535,7 +533,8 @@ public class StreamHandlerTest
     {
         File targetFile = tempFile();
 
-        new FakeStreamHandler() {
+        new FakeStreamHandler()
+        {
             @Override
             protected InputStream getInputStream()
             {
@@ -561,7 +560,8 @@ public class StreamHandlerTest
     {
         try (ByteArrayOutputStream os = new ByteArrayOutputStream())
         {
-            new FakeStreamHandler() {
+            new FakeStreamHandler()
+            {
                 @Override
                 protected InputStream getInputStream()
                 {
@@ -574,67 +574,6 @@ public class StreamHandlerTest
                     return os;
                 }
             }.handleTransformRequest();
-        }
-    }
-
-    @Test
-    public void testStartWithInputStreamAndCallCreateSourceFileForDocxFiles() throws Exception
-    {
-        try (InputStream inputStream = getSourceInputStreamFromBytes();
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
-        {
-            transformManager.setSourceFileName("test.docx");
-            transformManager.setInputStream(inputStream);
-            OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
-
-            File sourceFileCreatedByTransform = transformManager.createSourceFile();
-            assertTrue(sourceFileCreatedByTransform.exists());
-            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
-
-            transformManager.copyTargetFileToOutputStream();
-            transformManager.getOutputStream().close();
-            closeInputStreamWithoutException(inputStream);
-            Long outputLength = transformManager.getOutputLength();
-            transformManager.deleteSourceFile();
-            transformManager.deleteTargetFile();
-
-            assertEquals(EXPECTED, read(outputStream));
-            assertEquals(EXPECTED.length(), outputLength);
-            assertFalse(sourceFileCreatedByTransform.exists());
-        }
-    }
-
-    @Test
-    public void testStartWithInputStreamAndCallCreateSourceFileForDocxFilesWithHttpRequest() throws Exception
-    {
-        try (InputStream inputStream = getSourceInputStreamFromBytes();
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
-        {
-            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
-            Part mockPart = Mockito.mock(Part.class);
-            Mockito.when(mockPart.getSubmittedFileName()).thenReturn("dummy.docx");
-            Collection<Part> parts = Arrays.asList(mockPart);
-            Mockito.when(mockRequest.getParts()).thenReturn(parts);
-
-            transformManager.setSourceMimetype("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-            transformManager.setInputStream(inputStream);
-            transformManager.setRequest(mockRequest);
-            OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
-
-            File sourceFileCreatedByTransform = transformManager.createSourceFile();
-            assertTrue(sourceFileCreatedByTransform.exists());
-            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
-
-            transformManager.copyTargetFileToOutputStream();
-            transformManager.getOutputStream().close();
-            closeInputStreamWithoutException(inputStream);
-            Long outputLength = transformManager.getOutputLength();
-            transformManager.deleteSourceFile();
-            transformManager.deleteTargetFile();
-
-            assertEquals(EXPECTED, read(outputStream));
-            assertEquals(EXPECTED.length(), outputLength);
-            assertFalse(sourceFileCreatedByTransform.exists());
         }
     }
 }

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
@@ -26,9 +26,9 @@
  */
 package org.alfresco.transform.base.transform;
 
-import org.alfresco.transform.base.CustomTransformer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -42,20 +42,24 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Part;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import org.alfresco.transform.base.CustomTransformer;
 
 /**
- * Tests {@link StreamHandler}, {@link TransformManagerImpl#createSourceFile()} and
- * {@link TransformManagerImpl#createTargetFile()} methods.
+ * Tests {@link StreamHandler}, {@link TransformManagerImpl#createSourceFile()} and {@link TransformManagerImpl#createTargetFile()} methods.
  */
 public class StreamHandlerTest
 {
     public static final String ORIGINAL = "Original";
     public static final String CHANGE = " plus some change";
-    public static final String EXPECTED = ORIGINAL+ CHANGE;
+    public static final String EXPECTED = ORIGINAL + CHANGE;
 
     TransformManagerImpl transformManager = new TransformManagerImpl();
     @TempDir
@@ -132,12 +136,12 @@ public class StreamHandlerTest
     public void testStartWithInputStream() throws Exception
     {
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -155,14 +159,14 @@ public class StreamHandlerTest
     public void testStartWithInputStreamAndCallCreateSourceFile() throws Exception
     {
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
             File sourceFileCreatedByTransform = transformManager.createSourceFile();
             assertTrue(sourceFileCreatedByTransform.exists());
-            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform)+CHANGE);
+            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -185,12 +189,12 @@ public class StreamHandlerTest
         transformManager.setSourceFile(sourceFile);
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(sourceFile));
-             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -213,14 +217,14 @@ public class StreamHandlerTest
         transformManager.setSourceFile(sourceFile);
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(sourceFile));
-             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
             File sourceFileCreatedByTransform = transformManager.createSourceFile();
             assertEquals(sourceFile, sourceFileCreatedByTransform);
-            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform)+CHANGE);
+            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -247,14 +251,14 @@ public class StreamHandlerTest
     public void testStartWithOutputStreamAndCallCreateTargetFile() throws Exception
     {
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
             transformManager.setOutputStream(outputStream);
 
             File targetFileCreatedByTransform = transformManager.createTargetFile();
             assertTrue(targetFileCreatedByTransform.exists());
-            write(targetFileCreatedByTransform, read(inputStream)+CHANGE);
+            write(targetFileCreatedByTransform, read(inputStream) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -276,12 +280,12 @@ public class StreamHandlerTest
         transformManager.setTargetFile(targetFile);
 
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -304,14 +308,14 @@ public class StreamHandlerTest
         transformManager.setTargetFile(targetFile);
 
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             transformManager.setOutputStream(outputStream);
 
             File targetFileCreatedByTransform = transformManager.createTargetFile();
             assertEquals(targetFile, targetFileCreatedByTransform);
-            write(targetFileCreatedByTransform, read(inputStream)+CHANGE);
+            write(targetFileCreatedByTransform, read(inputStream) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();
@@ -344,12 +348,12 @@ public class StreamHandlerTest
         transformManager.keepTargetFile();
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(sourceFile));
-             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -375,12 +379,12 @@ public class StreamHandlerTest
         transformManager.setTargetFile(targetFile);
 
         try (InputStream inputStream = new BufferedInputStream(new FileInputStream(sourceFile));
-             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -404,12 +408,12 @@ public class StreamHandlerTest
         transformManager.setTargetFile(targetFile);
 
         try (InputStream inputStream = getSourceInputStreamFromBytes();
-             OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
+                OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetFile)))
         {
             transformManager.setInputStream(inputStream);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
-            write(outputStreamLengthRecorder, read(inputStream)+CHANGE);
+            write(outputStreamLengthRecorder, read(inputStream) + CHANGE);
 
             transformManager.copyTargetFileToOutputStream();
             closeInputStreamWithoutException(inputStream);
@@ -437,7 +441,7 @@ public class StreamHandlerTest
         @Override
         protected void transform(CustomTransformer customTransformer) throws Exception
         {
-            write(outputStream, read(inputStream)+CHANGE);
+            write(outputStream, read(inputStream) + CHANGE);
         }
     }
 
@@ -448,8 +452,7 @@ public class StreamHandlerTest
 
         try (ByteArrayOutputStream os = new ByteArrayOutputStream())
         {
-            new FakeStreamHandler()
-            {
+            new FakeStreamHandler() {
                 @Override
                 protected void init() throws IOException
                 {
@@ -480,8 +483,7 @@ public class StreamHandlerTest
         File sourceFile = tempFile();
         write(sourceFile, ORIGINAL);
 
-        new FakeStreamHandler()
-        {
+        new FakeStreamHandler() {
             @Override
             protected void init() throws IOException
             {
@@ -512,8 +514,7 @@ public class StreamHandlerTest
         File sourceFile = tempFile();
         write(sourceFile, ORIGINAL);
 
-        new FakeStreamHandler()
-        {
+        new FakeStreamHandler() {
             @Override
             protected InputStream getInputStream() throws IOException
             {
@@ -533,8 +534,7 @@ public class StreamHandlerTest
     {
         File targetFile = tempFile();
 
-        new FakeStreamHandler()
-        {
+        new FakeStreamHandler() {
             @Override
             protected InputStream getInputStream()
             {
@@ -560,8 +560,7 @@ public class StreamHandlerTest
     {
         try (ByteArrayOutputStream os = new ByteArrayOutputStream())
         {
-            new FakeStreamHandler()
-            {
+            new FakeStreamHandler() {
                 @Override
                 protected InputStream getInputStream()
                 {
@@ -574,6 +573,68 @@ public class StreamHandlerTest
                     return os;
                 }
             }.handleTransformRequest();
+        }
+    }
+
+    @Test
+    public void testStartWithInputStreamAndCallCreateSourceFileForDocxFiles() throws Exception
+    {
+        try (
+                InputStream in = getSourceInputStreamFromBytes();
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                OutputStream rec = transformManager.setOutputStream(out))
+        {
+            transformManager.setSourceFileName("test.docx");
+            transformManager.setInputStream(in);
+
+            File src = transformManager.createSourceFile();
+            assertTrue(src.exists());
+            write(rec, read(src) + CHANGE);
+
+            transformManager.copyTargetFileToOutputStream();
+            transformManager.getOutputStream().close();
+            closeInputStreamWithoutException(in);
+            Long outputLength = transformManager.getOutputLength();
+            transformManager.deleteSourceFile();
+            transformManager.deleteTargetFile();
+
+            assertEquals(EXPECTED, read(out));
+            assertEquals(EXPECTED.length(), outputLength);
+            assertFalse(src.exists());
+        }
+    }
+
+    @Test
+    public void testStartWithInputStreamAndCallCreateSourceFileForDocxFilesWithHttpRequest() throws Exception
+    {
+        try (
+                InputStream in = getSourceInputStreamFromBytes();
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                OutputStream rec = transformManager.setOutputStream(out))
+        {
+            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+            Part mockPart = Mockito.mock(Part.class);
+            Mockito.when(mockPart.getSubmittedFileName()).thenReturn("dummy.docx");
+            Mockito.when(mockRequest.getParts()).thenReturn(Arrays.asList(mockPart));
+
+            transformManager.setSourceMimetype("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+            transformManager.setInputStream(in);
+            transformManager.setRequest(mockRequest);
+
+            File src = transformManager.createSourceFile();
+            assertTrue(src.exists());
+            write(rec, read(src) + CHANGE);
+
+            transformManager.copyTargetFileToOutputStream();
+            transformManager.getOutputStream().close();
+            closeInputStreamWithoutException(in);
+            Long outputLength = transformManager.getOutputLength();
+            transformManager.deleteSourceFile();
+            transformManager.deleteTargetFile();
+
+            assertEquals(EXPECTED, read(out));
+            assertEquals(EXPECTED.length(), outputLength);
+            assertFalse(src.exists());
         }
     }
 }

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
@@ -55,6 +55,7 @@ import org.alfresco.transform.base.CustomTransformer;
 /**
  * Tests {@link StreamHandler}, {@link TransformManagerImpl#createSourceFile()} and {@link TransformManagerImpl#createTargetFile()} methods.
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public class StreamHandlerTest
 {
     public static final String ORIGINAL = "Original";

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
@@ -81,12 +81,6 @@ public class StreamHandlerTest
         return new BufferedInputStream(new FileInputStream(sourceFile));
     }
 
-    private File tempDocFile() throws IOException
-    {
-        return File.createTempFile("temp_", ".docx", tempDir);
-
-    }
-
     private File tempFile() throws IOException
     {
         return File.createTempFile("temp_", null, tempDir);
@@ -169,67 +163,6 @@ public class StreamHandlerTest
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
         {
             transformManager.setInputStream(inputStream);
-            OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
-
-            File sourceFileCreatedByTransform = transformManager.createSourceFile();
-            assertTrue(sourceFileCreatedByTransform.exists());
-            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
-
-            transformManager.copyTargetFileToOutputStream();
-            transformManager.getOutputStream().close();
-            closeInputStreamWithoutException(inputStream);
-            Long outputLength = transformManager.getOutputLength();
-            transformManager.deleteSourceFile();
-            transformManager.deleteTargetFile();
-
-            assertEquals(EXPECTED, read(outputStream));
-            assertEquals(EXPECTED.length(), outputLength);
-            assertFalse(sourceFileCreatedByTransform.exists());
-        }
-    }
-
-    @Test
-    public void testStartWithInputStreamAndCallCreateSourceFileForDocxFiles() throws Exception
-    {
-        try (InputStream inputStream = getSourceInputStreamFromBytes();
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
-        {
-            transformManager.setSourceFileName("test.docx");
-            transformManager.setInputStream(inputStream);
-            OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
-
-            File sourceFileCreatedByTransform = transformManager.createSourceFile();
-            assertTrue(sourceFileCreatedByTransform.exists());
-            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
-
-            transformManager.copyTargetFileToOutputStream();
-            transformManager.getOutputStream().close();
-            closeInputStreamWithoutException(inputStream);
-            Long outputLength = transformManager.getOutputLength();
-            transformManager.deleteSourceFile();
-            transformManager.deleteTargetFile();
-
-            assertEquals(EXPECTED, read(outputStream));
-            assertEquals(EXPECTED.length(), outputLength);
-            assertFalse(sourceFileCreatedByTransform.exists());
-        }
-    }
-
-    @Test
-    public void testStartWithInputStreamAndCallCreateSourceFileForDocxFilesWithHttpRequest() throws Exception
-    {
-        try (InputStream inputStream = getSourceInputStreamFromBytes();
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
-        {
-            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
-            Part mockPart = Mockito.mock(Part.class);
-            Mockito.when(mockPart.getSubmittedFileName()).thenReturn("dummy.docx");
-            Collection<Part> parts = Arrays.asList(mockPart);
-            Mockito.when(mockRequest.getParts()).thenReturn(parts);
-
-            transformManager.setSourceMimetype("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-            transformManager.setInputStream(inputStream);
-            transformManager.setRequest(mockRequest);
             OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
 
             File sourceFileCreatedByTransform = transformManager.createSourceFile();
@@ -641,6 +574,67 @@ public class StreamHandlerTest
                     return os;
                 }
             }.handleTransformRequest();
+        }
+    }
+
+    @Test
+    public void testStartWithInputStreamAndCallCreateSourceFileForDocxFiles() throws Exception
+    {
+        try (InputStream inputStream = getSourceInputStreamFromBytes();
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+        {
+            transformManager.setSourceFileName("test.docx");
+            transformManager.setInputStream(inputStream);
+            OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
+
+            File sourceFileCreatedByTransform = transformManager.createSourceFile();
+            assertTrue(sourceFileCreatedByTransform.exists());
+            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
+
+            transformManager.copyTargetFileToOutputStream();
+            transformManager.getOutputStream().close();
+            closeInputStreamWithoutException(inputStream);
+            Long outputLength = transformManager.getOutputLength();
+            transformManager.deleteSourceFile();
+            transformManager.deleteTargetFile();
+
+            assertEquals(EXPECTED, read(outputStream));
+            assertEquals(EXPECTED.length(), outputLength);
+            assertFalse(sourceFileCreatedByTransform.exists());
+        }
+    }
+
+    @Test
+    public void testStartWithInputStreamAndCallCreateSourceFileForDocxFilesWithHttpRequest() throws Exception
+    {
+        try (InputStream inputStream = getSourceInputStreamFromBytes();
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+        {
+            HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+            Part mockPart = Mockito.mock(Part.class);
+            Mockito.when(mockPart.getSubmittedFileName()).thenReturn("dummy.docx");
+            Collection<Part> parts = Arrays.asList(mockPart);
+            Mockito.when(mockRequest.getParts()).thenReturn(parts);
+
+            transformManager.setSourceMimetype("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+            transformManager.setInputStream(inputStream);
+            transformManager.setRequest(mockRequest);
+            OutputStream outputStreamLengthRecorder = transformManager.setOutputStream(outputStream);
+
+            File sourceFileCreatedByTransform = transformManager.createSourceFile();
+            assertTrue(sourceFileCreatedByTransform.exists());
+            write(outputStreamLengthRecorder, read(sourceFileCreatedByTransform) + CHANGE);
+
+            transformManager.copyTargetFileToOutputStream();
+            transformManager.getOutputStream().close();
+            closeInputStreamWithoutException(inputStream);
+            Long outputLength = transformManager.getOutputLength();
+            transformManager.deleteSourceFile();
+            transformManager.deleteTargetFile();
+
+            assertEquals(EXPECTED, read(outputStream));
+            assertEquals(EXPECTED.length(), outputLength);
+            assertFalse(sourceFileCreatedByTransform.exists());
         }
     }
 }

--- a/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/transform/StreamHandlerTest.java
@@ -585,12 +585,14 @@ public class StreamHandlerTest
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 OutputStream rec = transformManager.setOutputStream(out))
         {
-            transformManager.setSourceFileName("test.docx");
+            String testFilename = "test.docx";
+            transformManager.setSourceFileName(testFilename);
             transformManager.setInputStream(in);
 
             File src = transformManager.createSourceFile();
             assertTrue(src.exists());
             write(rec, read(src) + CHANGE);
+            assertEquals(testFilename, src.getName());
 
             transformManager.copyTargetFileToOutputStream();
             transformManager.getOutputStream().close();

--- a/model/src/main/java/org/alfresco/transform/client/model/TransformRequest.java
+++ b/model/src/main/java/org/alfresco/transform/client/model/TransformRequest.java
@@ -310,6 +310,11 @@ public class TransformRequest implements Serializable
             return this;
         }
 
+        public Builder withSourceFileName(final String sourceFileName) {
+            request.sourceFileName = sourceFileName;
+            return this;
+        }
+
         public TransformRequest build()
         {
             return request;

--- a/model/src/main/java/org/alfresco/transform/client/model/TransformRequest.java
+++ b/model/src/main/java/org/alfresco/transform/client/model/TransformRequest.java
@@ -48,6 +48,7 @@ public class TransformRequest implements Serializable
     private int schema;
     private Map<String, String> transformRequestOptions = new HashMap<>();
     private InternalContext internalContext;
+    private String sourceFileName;
 
     // regions [Accessors]
     public String getRequestId()
@@ -158,6 +159,14 @@ public class TransformRequest implements Serializable
     public void setInternalContext(InternalContext internalContext)
     {
         this.internalContext = internalContext;
+    }
+
+    public String getSourceFileName() {
+        return sourceFileName;
+    }
+
+    public void setSourceFileName(String sourceFileName) {
+        this.sourceFileName = sourceFileName;
     }
 
     //endregion

--- a/model/src/main/java/org/alfresco/transform/client/model/TransformRequest.java
+++ b/model/src/main/java/org/alfresco/transform/client/model/TransformRequest.java
@@ -21,17 +21,17 @@
  */
 package org.alfresco.transform.client.model;
 
-import org.alfresco.transform.common.ExtensionService;
-import org.alfresco.transform.messages.TransformStack;
+import static org.alfresco.transform.messages.TransformStack.PIPELINE_FLAG;
+import static org.alfresco.transform.messages.TransformStack.levelBuilder;
+import static org.alfresco.transform.messages.TransformStack.setInitialTransformRequestOptions;
 
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.alfresco.transform.messages.TransformStack.PIPELINE_FLAG;
-import static org.alfresco.transform.messages.TransformStack.levelBuilder;
-import static org.alfresco.transform.messages.TransformStack.setInitialTransformRequestOptions;
+import org.alfresco.transform.common.ExtensionService;
+import org.alfresco.transform.messages.TransformStack;
 
 // This class is in the package org.alfresco.transform.messages in HxP because that is more readable, but in
 // org.alfresco.transform.client.model in Alfresco for backward compatibility.
@@ -161,15 +161,17 @@ public class TransformRequest implements Serializable
         this.internalContext = internalContext;
     }
 
-    public String getSourceFileName() {
+    public String getSourceFileName()
+    {
         return sourceFileName;
     }
 
-    public void setSourceFileName(String sourceFileName) {
+    public void setSourceFileName(String sourceFileName)
+    {
         this.sourceFileName = sourceFileName;
     }
 
-    //endregion
+    // endregion
 
     @Override
     public boolean equals(Object o)
@@ -188,34 +190,32 @@ public class TransformRequest implements Serializable
         return Objects.hash(requestId);
     }
 
-    @Override public String toString()
+    @Override
+    public String toString()
     {
         return "TransformRequest{" +
-               "requestId='" + requestId + '\'' +
-               ", sourceReference='" + sourceReference + '\'' +
-               ", sourceMediaType='" + sourceMediaType + '\'' +
-               ", sourceSize=" + sourceSize +
-               ", sourceExtension='" + sourceExtension + '\'' +
-               ", targetMediaType='" + targetMediaType + '\'' +
-               ", targetExtension='" + targetExtension + '\'' +
-               ", clientData='" + clientData + '\'' +
-               ", schema=" + schema +
-               ", transformRequestOptions=" + transformRequestOptions +
-               ", internalContext=" + internalContext +
-               '}';
+                "requestId='" + requestId + '\'' +
+                ", sourceReference='" + sourceReference + '\'' +
+                ", sourceMediaType='" + sourceMediaType + '\'' +
+                ", sourceSize=" + sourceSize +
+                ", sourceExtension='" + sourceExtension + '\'' +
+                ", targetMediaType='" + targetMediaType + '\'' +
+                ", targetExtension='" + targetExtension + '\'' +
+                ", clientData='" + clientData + '\'' +
+                ", schema=" + schema +
+                ", transformRequestOptions=" + transformRequestOptions +
+                ", internalContext=" + internalContext +
+                '}';
     }
 
     /**
-     * Sets up the internal context structure when a client request is initially received by the router,
-     * so that we don't have to keep checking if bits of it are initialised. Prior to making this call,
-     * the id, sourceMimetypes, targetMimetype, transformRequestOptions and sourceReference should have
-     * been set, if they are to be set.
+     * Sets up the internal context structure when a client request is initially received by the router, so that we don't have to keep checking if bits of it are initialised. Prior to making this call, the id, sourceMimetypes, targetMimetype, transformRequestOptions and sourceReference should have been set, if they are to be set.
      */
     public TransformRequest initialiseContextWhenReceivedByRouter()
     {
         setInternalContext(InternalContext.initialise(getInternalContext()));
         setTargetExtension(ExtensionService.getExtensionForTargetMimetype(getTargetMediaType(),
-            getSourceMediaType()));
+                getSourceMediaType()));
         getInternalContext().getMultiStep().setInitialRequestId(getRequestId());
         getInternalContext().getMultiStep().setInitialSourceMediaType(getSourceMediaType());
         getInternalContext().setTransformRequestOptions(getTransformRequestOptions());
@@ -233,7 +233,8 @@ public class TransformRequest implements Serializable
     {
         private final TransformRequest request = new TransformRequest();
 
-        private Builder() {}
+        private Builder()
+        {}
 
         public Builder withRequestId(final String requestId)
         {
@@ -290,7 +291,7 @@ public class TransformRequest implements Serializable
         }
 
         public Builder withTransformRequestOptions(
-            final Map<String, String> transformRequestOptions)
+                final Map<String, String> transformRequestOptions)
         {
             request.transformRequestOptions = transformRequestOptions;
             return this;
@@ -306,11 +307,12 @@ public class TransformRequest implements Serializable
         {
             request.initialiseContextWhenReceivedByRouter();
             TransformStack.addTransformLevel(request.internalContext, levelBuilder(PIPELINE_FLAG)
-                .withStep("dummyTransformerName", request.sourceMediaType, request.targetMediaType));
+                    .withStep("dummyTransformerName", request.sourceMediaType, request.targetMediaType));
             return this;
         }
 
-        public Builder withSourceFileName(final String sourceFileName) {
+        public Builder withSourceFileName(final String sourceFileName)
+        {
             request.sourceFileName = sourceFileName;
             return this;
         }


### PR DESCRIPTION
PR contains changes for the Issue [/MNT-24883](https://hyland.atlassian.net/browse/MNT-24883)

**Changes**
 While converting files via any engine , file will be stored inside a temp folder(folder name : uuid generated) with the original filename. 
 
 Similar changes in 
 https://github.com/Alfresco/alfresco-transform-service/pull/1019
 https://github.com/Alfresco/alfresco-community-repo/pull/3366