### PR TITLE
[ACS-9839] Introduced ACTIVEMQ_URL_PARAMS to avoid the need to override spring.activemq.broker-url directly

### DIFF
--- a/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/MessagingInfo.java
+++ b/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/MessagingInfo.java
@@ -55,9 +55,9 @@ public class MessagingInfo
         // For backwards-compatibility, we continue to rely on setting ACTIVEMQ_URL environment variable (see application.yaml)
         // The MessagingConfig class uses on ConditionalOnProperty (ie. activemq.url is set and not false)
 
-        // Note: as per application.yaml the broker url is appended with ACTIVEMQ_CONN_OPTIONS with default value "?jms.watchTopicAdvisories=false".
+        // Note: as per application.yaml the broker url is appended with ACTIVEMQ_URL_PARAMS with default value "?jms.watchTopicAdvisories=false".
         // If this needs to be fully overridden then it would require explicitly setting both "spring.activemq.broker-url"
-        // *and* "activemq.url" (latter to non-false value). ACTIVEMQ_CONN_OPTIONS value will be ignored in that case.
+        // *and* "activemq.url" (latter to non-false value). ACTIVEMQ_URL_PARAMS value will be ignored in that case.
 
         if ((activemqUrl != null) && (! activemqUrl.equals("false")))
         {

--- a/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/MessagingInfo.java
+++ b/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/MessagingInfo.java
@@ -55,8 +55,9 @@ public class MessagingInfo
         // For backwards-compatibility, we continue to rely on setting ACTIVEMQ_URL environment variable (see application.yaml)
         // The MessagingConfig class uses on ConditionalOnProperty (ie. activemq.url is set and not false)
 
-        // Note: as per application.yaml the broker url is appended with "?jms.watchTopicAdvisories=false". If this needs to be fully
-        // overridden then it would require explicitly setting both "spring.activemq.broker-url" *and* "activemq.url" (latter to non-false value).
+        // Note: as per application.yaml the broker url is appended with ACTIVEMQ_CONN_OPTIONS with default value "?jms.watchTopicAdvisories=false".
+        // If this needs to be fully overridden then it would require explicitly setting both "spring.activemq.broker-url"
+        // *and* "activemq.url" (latter to non-false value). ACTIVEMQ_CONN_OPTIONS value will be ignored in that case.
 
         if ((activemqUrl != null) && (! activemqUrl.equals("false")))
         {

--- a/deprecated/alfresco-transformer-base/src/main/resources/application.yaml
+++ b/deprecated/alfresco-transformer-base/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
       max-file-size: 8192MB
       max-request-size: 8192MB
   activemq:
-    broker-url: ${ACTIVEMQ_URL:nio://localhost:61616}?jms.watchTopicAdvisories=false
+    broker-url: ${ACTIVEMQ_URL:nio://localhost:61616}${ACTIVEMQ_CONN_OPTIONS:?jms.watchTopicAdvisories=false}
     user: ${ACTIVEMQ_USER:admin}
     password: ${ACTIVEMQ_PASSWORD:admin}
     pool:

--- a/deprecated/alfresco-transformer-base/src/main/resources/application.yaml
+++ b/deprecated/alfresco-transformer-base/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
       max-file-size: 8192MB
       max-request-size: 8192MB
   activemq:
-    broker-url: ${ACTIVEMQ_URL:nio://localhost:61616}${ACTIVEMQ_CONN_OPTIONS:?jms.watchTopicAdvisories=false}
+    broker-url: ${ACTIVEMQ_URL:nio://localhost:61616}${ACTIVEMQ_URL_PARAMS:?jms.watchTopicAdvisories=false}
     user: ${ACTIVEMQ_USER:admin}
     password: ${ACTIVEMQ_PASSWORD:admin}
     pool:

--- a/docs/external-engine-configuration.md
+++ b/docs/external-engine-configuration.md
@@ -12,6 +12,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
+| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | PDFBOX_NOTEXTRACTBOOKMARKS_DEFAULT | The default behaviour for notExtractBookmarksText when this request param is omitted from a request. | false |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for receiving async requests. | org.alfresco.transform.engine.tika.acs |
@@ -25,6 +26,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
+| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.alfresco-pdf-renderer.acs |
 | PDFRENDERER_EXE | Path to Pdf-renderer EXE. | /usr/bin/alfresco-pdf-renderer |
@@ -37,6 +39,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
+| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.misc.acs |
 | MISC_PDFBOX_DEFAULT_FONT | Default font used by PdfBox | NotoSans-Regular |
@@ -50,6 +53,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
+| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.libreoffice.acs |
 | LIBREOFFICE_HOME | Path to LibreOffice_Home.  | /opt/libreoffice7.2 |
@@ -67,6 +71,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
+| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.imagemagick.acs |
 | IMAGEMAGICK_ROOT | Path to Imagemagick Root. | /usr/lib64/ImageMagick-7.0.10 |
@@ -83,6 +88,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
+| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | PDFBOX_NOTEXTRACTBOOKMARKS_DEFAULT | The default behaviour for notExtractBookmarksText when this request param is omitted from a request. | false |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.aio.acs |

--- a/docs/external-engine-configuration.md
+++ b/docs/external-engine-configuration.md
@@ -12,7 +12,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
-| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
+| ACTIVEMQ_URL_PARAMS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | PDFBOX_NOTEXTRACTBOOKMARKS_DEFAULT | The default behaviour for notExtractBookmarksText when this request param is omitted from a request. | false |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for receiving async requests. | org.alfresco.transform.engine.tika.acs |
@@ -26,7 +26,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
-| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
+| ACTIVEMQ_URL_PARAMS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.alfresco-pdf-renderer.acs |
 | PDFRENDERER_EXE | Path to Pdf-renderer EXE. | /usr/bin/alfresco-pdf-renderer |
@@ -39,7 +39,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
-| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
+| ACTIVEMQ_URL_PARAMS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.misc.acs |
 | MISC_PDFBOX_DEFAULT_FONT | Default font used by PdfBox | NotoSans-Regular |
@@ -53,7 +53,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
-| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
+| ACTIVEMQ_URL_PARAMS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.libreoffice.acs |
 | LIBREOFFICE_HOME | Path to LibreOffice_Home.  | /opt/libreoffice7.2 |
@@ -71,7 +71,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
-| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
+| ACTIVEMQ_URL_PARAMS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.imagemagick.acs |
 | IMAGEMAGICK_ROOT | Path to Imagemagick Root. | /usr/lib64/ImageMagick-7.0.10 |
@@ -88,7 +88,7 @@ The following externalized T-engines properties are available:
 | ACTIVEMQ_URL | ActiveMQ URL. | nio://localhost:61616 |
 | ACTIVEMQ_USER | ActiveMQ User. | admin |
 | ACTIVEMQ_PASSWORD | ActiveMQ Password. | admin |
-| ACTIVEMQ_CONN_OPTIONS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
+| ACTIVEMQ_URL_PARAMS | ActiveMQ connection options. | ?jms.watchTopicAdvisories=false |
 | FILE_STORE_URL | T-Engine Port. | http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file |
 | PDFBOX_NOTEXTRACTBOOKMARKS_DEFAULT | The default behaviour for notExtractBookmarksText when this request param is omitted from a request. | false |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | T-Engine queue used for async requests. | org.alfresco.transform.engine.aio.acs |

--- a/docs/t-engine-scaling.md
+++ b/docs/t-engine-scaling.md
@@ -145,11 +145,11 @@ Vertical scaling can be achieved through Docker, JVM, Spring Boot, or ActiveMQ c
   **Default:** 1 set by Spring Autoconfiguration, 1-10 set by base engine's application.yaml
 
 
-- **`SPRING_ACTIVEMQ_BROKERURL` with `jms.prefetchPolicy.all` (Spring Boot/ActiveMQ):**  
-  Sets the ActiveMQ broker URL. Use this property to configure the broker connection, including prefetch policy settings.
+- **`ACTIVEMQ_CONN_OPTIONS` with `jms.prefetchPolicy.all` (Spring Boot/ActiveMQ):**  
+  Overrides the default ActiveMQ connection options of broker URL by including prefetch policy settings.
   It controls how many messages are prefetched from the queue by each consumer before processing. A higher prefetch value can
   improve throughput but may increase memory usage. Note that raising this number might lead to starvation of concurrent consumers!  
-  **Default:** `tcp://localhost:61616` (prefetch policy default is 1000 for queues)
+  **Default:** `?jms.watchTopicAdvisories=false` (prefetch policy default is 1000 for queues)
 
   **Note:** The T-Engines consumers should be considered as slow consumers. Processing each message can take a significant amount of time.
   So, the prefetch size should be correctly set (based on performance tests) to distribute the messages equally across the nodes
@@ -172,7 +172,7 @@ Below is a single example that combines memory limits, JVM options, concurrency,
       ACTIVEMQ_URL: nio://activemq:61616
       FILE_STORE_URL: >-
         http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file
-      SPRING_ACTIVEMQ_BROKERURL: "nio://activemq:61616?jms.prefetchPolicy.all=100" # Decreases the message prefetch
+      ACTIVEMQ_CONN_OPTIONS: ?jms.watchTopicAdvisories=false&jms.prefetchPolicy.all=100
       SPRING_ACTIVEMQ_POOL_MAXCONNECTIONS: 100 # Increases the ActiveMQ connection pool 
       JMS_LISTENER_CONCURRENCY: 1-100 # Increases the JMS listener concurrency
     ports:

--- a/docs/t-engine-scaling.md
+++ b/docs/t-engine-scaling.md
@@ -145,7 +145,7 @@ Vertical scaling can be achieved through Docker, JVM, Spring Boot, or ActiveMQ c
   **Default:** 1 set by Spring Autoconfiguration, 1-10 set by base engine's application.yaml
 
 
-- **`ACTIVEMQ_CONN_OPTIONS` with `jms.prefetchPolicy.all` (Spring Boot/ActiveMQ):**  
+- **`ACTIVEMQ_URL_PARAMS` with `jms.prefetchPolicy.all` (Spring Boot/ActiveMQ):**  
   Overrides the default ActiveMQ connection options of broker URL by including prefetch policy settings.
   It controls how many messages are prefetched from the queue by each consumer before processing. A higher prefetch value can
   improve throughput but may increase memory usage. Note that raising this number might lead to starvation of concurrent consumers!  
@@ -172,7 +172,7 @@ Below is a single example that combines memory limits, JVM options, concurrency,
       ACTIVEMQ_URL: nio://activemq:61616
       FILE_STORE_URL: >-
         http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file
-      ACTIVEMQ_CONN_OPTIONS: ?jms.watchTopicAdvisories=false&jms.prefetchPolicy.all=100
+      ACTIVEMQ_URL_PARAMS: ?jms.watchTopicAdvisories=false&jms.prefetchPolicy.all=100
       SPRING_ACTIVEMQ_POOL_MAXCONNECTIONS: 100 # Increases the ActiveMQ connection pool 
       JMS_LISTENER_CONCURRENCY: 1-100 # Increases the JMS listener concurrency
     ports:

--- a/docs/t-engine-scaling.md
+++ b/docs/t-engine-scaling.md
@@ -172,7 +172,7 @@ Below is a single example that combines memory limits, JVM options, concurrency,
       ACTIVEMQ_URL: nio://activemq:61616
       FILE_STORE_URL: >-
         http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file
-      ACTIVEMQ_URL_PARAMS: ?jms.watchTopicAdvisories=false&jms.prefetchPolicy.all=100
+      ACTIVEMQ_URL_PARAMS: ?jms.watchTopicAdvisories=false&jms.prefetchPolicy.all=100 # Decreases the message prefetch
       SPRING_ACTIVEMQ_POOL_MAXCONNECTIONS: 100 # Increases the ActiveMQ connection pool 
       JMS_LISTENER_CONCURRENCY: 1-100 # Increases the JMS listener concurrency
     ports:

--- a/engines/base/src/main/java/org/alfresco/transform/base/messaging/MessagingInfo.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/messaging/MessagingInfo.java
@@ -52,8 +52,9 @@ public class MessagingInfo
         // For backwards-compatibility, we continue to rely on setting ACTIVEMQ_URL environment variable (see application.yaml)
         // The MessagingConfig class uses on ConditionalOnProperty (ie. activemq.url is set and not false)
 
-        // Note: as per application.yaml the broker url is appended with "?jms.watchTopicAdvisories=false". If this needs to be fully
-        // overridden then it would require explicitly setting both "spring.activemq.broker-url" *and* "activemq.url" (latter to non-false value).
+        // Note: as per application.yaml the broker url is appended with ACTIVEMQ_CONN_OPTIONS with default value "?jms.watchTopicAdvisories=false".
+        // If this needs to be fully overridden then it would require explicitly setting both "spring.activemq.broker-url"
+        // *and* "activemq.url" (latter to non-false value). ACTIVEMQ_CONN_OPTIONS value will be ignored in that case.
 
         if ((activemqUrl != null) && (! activemqUrl.equals("false")))
         {

--- a/engines/base/src/main/java/org/alfresco/transform/base/messaging/MessagingInfo.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/messaging/MessagingInfo.java
@@ -52,9 +52,9 @@ public class MessagingInfo
         // For backwards-compatibility, we continue to rely on setting ACTIVEMQ_URL environment variable (see application.yaml)
         // The MessagingConfig class uses on ConditionalOnProperty (ie. activemq.url is set and not false)
 
-        // Note: as per application.yaml the broker url is appended with ACTIVEMQ_CONN_OPTIONS with default value "?jms.watchTopicAdvisories=false".
+        // Note: as per application.yaml the broker url is appended with ACTIVEMQ_URL_PARAMS with default value "?jms.watchTopicAdvisories=false".
         // If this needs to be fully overridden then it would require explicitly setting both "spring.activemq.broker-url"
-        // *and* "activemq.url" (latter to non-false value). ACTIVEMQ_CONN_OPTIONS value will be ignored in that case.
+        // *and* "activemq.url" (latter to non-false value). ACTIVEMQ_URL_PARAMS value will be ignored in that case.
 
         if ((activemqUrl != null) && (! activemqUrl.equals("false")))
         {

--- a/engines/base/src/main/resources/application.yaml
+++ b/engines/base/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
       max-file-size: 8192MB
       max-request-size: 8192MB
   activemq:
-    broker-url: ${ACTIVEMQ_URL:nio://localhost:61616}?jms.watchTopicAdvisories=false
+    broker-url: ${ACTIVEMQ_URL:nio://localhost:61616}${ACTIVEMQ_CONN_OPTIONS:?jms.watchTopicAdvisories=false}
     user: ${ACTIVEMQ_USER:admin}
     password: ${ACTIVEMQ_PASSWORD:admin}
     pool:

--- a/engines/base/src/main/resources/application.yaml
+++ b/engines/base/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
       max-file-size: 8192MB
       max-request-size: 8192MB
   activemq:
-    broker-url: ${ACTIVEMQ_URL:nio://localhost:61616}${ACTIVEMQ_CONN_OPTIONS:?jms.watchTopicAdvisories=false}
+    broker-url: ${ACTIVEMQ_URL:nio://localhost:61616}${ACTIVEMQ_URL_PARAMS:?jms.watchTopicAdvisories=false}
     user: ${ACTIVEMQ_USER:admin}
     password: ${ACTIVEMQ_PASSWORD:admin}
     pool:


### PR DESCRIPTION
https://hyland.atlassian.net/browse/ACS-9839
Also see https://github.com/Alfresco/alfresco-transform-service/pull/1067