### PR TITLE
[ACS-9839] Additional logging

### DIFF
--- a/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/MessagingInfo.java
+++ b/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/MessagingInfo.java
@@ -52,6 +52,9 @@ public class MessagingInfo
     @Value("${spring.activemq.broker-url}")
     private String activemqBrokerUrl;
 
+    @Value("${activemq.url.params}")
+    private String activemqUrlParams;
+
     @PostConstruct
     public void init()
     {
@@ -62,7 +65,7 @@ public class MessagingInfo
         // If this needs to be fully overridden then it would require explicitly setting both "spring.activemq.broker-url"
         // *and* "activemq.url" (latter to non-false value). ACTIVEMQ_URL_PARAMS value will be ignored in that case.
 
-        if ((activemqUrl != null) && (!activemqUrl.equals("false")))
+        if (isSet(activemqUrl))
         {
             logger.info("JMS client is ENABLED - ACTIVEMQ_URL ='{}'", activemqUrl);
         }
@@ -70,6 +73,19 @@ public class MessagingInfo
         {
             logger.info("JMS client is DISABLED - ACTIVEMQ_URL is not set");
         }
-        logger.debug("spring.activemq.broker-url={}", activemqBrokerUrl);
+        if (isSet(activemqUrlParams))
+        {
+            logger.info("ACTIVEMQ_URL_PARAMS ='{}'", activemqUrlParams);
+        }
+        else
+        {
+            logger.info("ACTIVEMQ_URL_PARAMS is not set");
+        }
+        logger.info("spring.activemq.broker-url='{}'", activemqBrokerUrl);
+    }
+
+    private boolean isSet(String value)
+    {
+        return !"false".equals(value);
     }
 }

--- a/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/MessagingInfo.java
+++ b/deprecated/alfresco-transformer-base/src/main/java/org/alfresco/transformer/messaging/MessagingInfo.java
@@ -49,6 +49,9 @@ public class MessagingInfo
     @Value("${activemq.url:}")
     private String activemqUrl;
 
+    @Value("${spring.activemq.broker-url}")
+    private String activemqBrokerUrl;
+
     @PostConstruct
     public void init()
     {
@@ -67,5 +70,6 @@ public class MessagingInfo
         {
             logger.info("JMS client is DISABLED - ACTIVEMQ_URL is not set");
         }
+        logger.debug("spring.activemq.broker-url={}", activemqBrokerUrl);
     }
 }

--- a/deprecated/alfresco-transformer-base/src/main/resources/application.yaml
+++ b/deprecated/alfresco-transformer-base/src/main/resources/application.yaml
@@ -16,6 +16,7 @@ spring:
 
 activemq:
   url: ${ACTIVEMQ_URL:false}
+  url.params: ${ACTIVEMQ_URL_PARAMS:false}
 
 server:
   port: ${SERVER_PORT:8090}

--- a/engines/base/src/main/java/org/alfresco/transform/base/messaging/MessagingInfo.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/messaging/MessagingInfo.java
@@ -46,6 +46,9 @@ public class MessagingInfo
     @Value("${activemq.url:}")
     private String activemqUrl;
 
+    @Value("${spring.activemq.broker-url}")
+    private String activemqBrokerUrl;
+
     @PostConstruct
     public void init()
     {
@@ -64,5 +67,6 @@ public class MessagingInfo
         {
             logger.info("JMS client is DISABLED - ACTIVEMQ_URL is not set");
         }
+        logger.debug("spring.activemq.broker-url={}", activemqBrokerUrl);
     }
 }

--- a/engines/base/src/main/java/org/alfresco/transform/base/messaging/MessagingInfo.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/messaging/MessagingInfo.java
@@ -49,6 +49,9 @@ public class MessagingInfo
     @Value("${spring.activemq.broker-url}")
     private String activemqBrokerUrl;
 
+    @Value("${activemq.url.params}")
+    private String activemqUrlParams;
+
     @PostConstruct
     public void init()
     {
@@ -59,7 +62,7 @@ public class MessagingInfo
         // If this needs to be fully overridden then it would require explicitly setting both "spring.activemq.broker-url"
         // *and* "activemq.url" (latter to non-false value). ACTIVEMQ_URL_PARAMS value will be ignored in that case.
 
-        if ((activemqUrl != null) && (!activemqUrl.equals("false")))
+        if (isSet(activemqUrl))
         {
             logger.info("JMS client is ENABLED - ACTIVEMQ_URL ='{}'", activemqUrl);
         }
@@ -67,6 +70,19 @@ public class MessagingInfo
         {
             logger.info("JMS client is DISABLED - ACTIVEMQ_URL is not set");
         }
-        logger.debug("spring.activemq.broker-url={}", activemqBrokerUrl);
+        if (isSet(activemqUrlParams))
+        {
+            logger.info("ACTIVEMQ_URL_PARAMS ='{}'", activemqUrlParams);
+        }
+        else
+        {
+            logger.info("ACTIVEMQ_URL_PARAMS is not set");
+        }
+        logger.info("spring.activemq.broker-url='{}'", activemqBrokerUrl);
+    }
+
+    private boolean isSet(String value)
+    {
+        return !"false".equals(value);
     }
 }

--- a/engines/base/src/main/resources/application.yaml
+++ b/engines/base/src/main/resources/application.yaml
@@ -16,6 +16,7 @@ spring:
 
 activemq:
   url: ${ACTIVEMQ_URL:false}
+  url.params: ${ACTIVEMQ_URL_PARAMS:false}
 
 server:
   port: ${SERVER_PORT:8090}


### PR DESCRIPTION
No env params:
```
2025-07-25T13:11:05.283+02:00  INFO 12220 --- [           main] o.a.t.base.messaging.MessagingInfo       : JMS client is DISABLED - ACTIVEMQ_URL is not set
2025-07-25T13:11:05.284+02:00  INFO 12220 --- [           main] o.a.t.base.messaging.MessagingInfo       : ACTIVEMQ_URL_PARAMS is not set
2025-07-25T13:11:05.284+02:00  INFO 12220 --- [           main] o.a.t.base.messaging.MessagingInfo       : spring.activemq.broker-url='nio://localhost:61616?jms.watchTopicAdvisories=false'
```
ACTIVEMQ_URL=nio://localhost:61616;ACTIVEMQ_URL_PARAMS=
```
2025-07-25T13:19:15.125+02:00  INFO 13133 --- [           main] o.a.t.base.messaging.MessagingInfo       : JMS client is ENABLED - ACTIVEMQ_URL ='nio://localhost:61616'
2025-07-25T13:19:15.125+02:00  INFO 13133 --- [           main] o.a.t.base.messaging.MessagingInfo       : ACTIVEMQ_URL_PARAMS =''
2025-07-25T13:19:15.125+02:00  INFO 13133 --- [           main] o.a.t.base.messaging.MessagingInfo       : spring.activemq.broker-url='nio://localhost:61616'
```
ACTIVEMQ_URL=nio://localhost:61616;ACTIVEMQ_URL_PARAMS=?jms.prefetchPolicy.all=100
```
2025-07-25T13:22:12.513+02:00  INFO 13318 --- [           main] o.a.t.base.messaging.MessagingInfo       : JMS client is ENABLED - ACTIVEMQ_URL ='nio://localhost:61616'
2025-07-25T13:22:12.514+02:00  INFO 13318 --- [           main] o.a.t.base.messaging.MessagingInfo       : ACTIVEMQ_URL_PARAMS ='?jms.prefetchPolicy.all=100'
2025-07-25T13:22:12.514+02:00  INFO 13318 --- [           main] o.a.t.base.messaging.MessagingInfo       : spring.activemq.broker-url='nio://localhost:61616?jms.prefetchPolicy.all=100'
```

With docker:
```
  transform-core-aio:
    image: alfresco/alfresco-transform-core-aio:${TRANSFORMERS_TAG}
    hostname: transform-core-aio
    networks:
      - transform
    ports:
      - 8097:8090
    environment:
      FILE_STORE_URL: "http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file"
      ACTIVEMQ_URL: "nio://activemq:61616"
      ACTIVEMQ_USER: "admin"
      ACTIVEMQ_PASSWORD: "admin"
```
<img width="920" height="599" alt="image" src="https://github.com/user-attachments/assets/9d7d12b7-788e-4392-a1d3-f5c5afdb0c63" />
