### PR TITLE
ACS-9926 added logic to skip TiffImageReader provided by JAI library

### DIFF
--- a/engines/misc/src/main/java/org/alfresco/transform/misc/transformers/ImageToPdfTransformer.java
+++ b/engines/misc/src/main/java/org/alfresco/transform/misc/transformers/ImageToPdfTransformer.java
@@ -78,6 +78,7 @@ public class ImageToPdfTransformer implements CustomTransformerFileAdaptor
     private static final String START_PAGE_GREATER_THAN_END_PAGE_ERROR_MESSAGE = "Start page number cannot be greater than end page.";
     private static final String INVALID_OPTION_ERROR_MESSAGE = "Parameter '%s' is invalid: \"%s\" - it must be an integer.";
     private static final String INVALID_IMAGE_ERROR_MESSAGE = "Image file (%s) format (%s) not supported by ImageIO.";
+    private static final String INVALID_IMAGE_READER_ERROR_MESSAGE = "No suitable ImageReader found for image file (%s) with format (%s).";
     private static final String DEFAULT_PDF_FORMAT_STRING = "DEFAULT"; // pdf format to use when no pdf format specified
     private static final String DEFAULT_PDF_ORIENTATION_STRING = "DEFAULT";
     private static final float PDFBOX_POINTS_PER_INCH = 72.0F;
@@ -130,10 +131,17 @@ public class ImageToPdfTransformer implements CustomTransformerFileAdaptor
         {
             throw new IOException(String.format(INVALID_IMAGE_ERROR_MESSAGE, imageName, mimetype));
         }
-        final ImageReader imageReader = imageReaders.next();
-        imageReader.setInput(imageInputStream);
-
-        return imageReader;
+        while (imageReaders.hasNext())
+        {
+            ImageReader reader = imageReaders.next();
+            // Skip the JAI TIFF reader if present (See MNT-25208)
+            if (!"com.github.jaiimageio.impl.plugins.tiff.TIFFImageReader".equals(reader.getClass().getName()))
+            {
+                reader.setInput(imageInputStream);
+                return reader;
+            }
+        }
+        throw new IOException(String.format(INVALID_IMAGE_READER_ERROR_MESSAGE, imageName, mimetype));
     }
 
     private void scaleAndDrawImage(final PDDocument pdfDocument, final BufferedImage bufferedImage, final String pdfFormat, final String pdfOrientation, final Map<String, Integer> resolution)


### PR DESCRIPTION
TiffImageReader Provided by JAI Library results in pitch black pdf transformation. Added logic to skip this one.
`ImageIo.getImageReaders` provides two implementation for `TIFFImageReader` , `com.github.jaiimageio.impl.plugins.tiff.TIFFImageReader` and `com.sun.imageio.plugins.tiff.TIFFImageReader`
and the later one works fine.