### PR TITLE
ACS-11867 Please [release] 5.4.3-A.7 [skip tests]

### DIFF
--- a/deprecated/alfresco-transformer-base/pom.xml
+++ b/deprecated/alfresco-transformer-base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/deprecated/alfresco-transformer-base/pom.xml
+++ b/deprecated/alfresco-transformer-base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/aio/pom.xml
+++ b/engines/aio/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/aio/pom.xml
+++ b/engines/aio/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/base/pom.xml
+++ b/engines/base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/base/pom.xml
+++ b/engines/base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/example/pom.xml
+++ b/engines/example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/example/pom.xml
+++ b/engines/example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/imagemagick/pom.xml
+++ b/engines/imagemagick/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/imagemagick/pom.xml
+++ b/engines/imagemagick/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/libreoffice/pom.xml
+++ b/engines/libreoffice/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/libreoffice/pom.xml
+++ b/engines/libreoffice/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/misc/pom.xml
+++ b/engines/misc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/misc/pom.xml
+++ b/engines/misc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/pdfrenderer/pom.xml
+++ b/engines/pdfrenderer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/pdfrenderer/pom.xml
+++ b/engines/pdfrenderer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/tika/pom.xml
+++ b/engines/tika/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/tika/pom.xml
+++ b/engines/tika/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-SNAPSHOT</version>
+        <version>5.4.3-A.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.3-A.2-SNAPSHOT</version>
+        <version>5.4.3-A.7-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-transform-core</artifactId>
-    <version>5.4.3-A.2-SNAPSHOT</version>
+    <version>5.4.3-A.7-SNAPSHOT</version>
     <name>Alfresco Transform Core</name>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-transform-core</artifactId>
-    <version>5.4.3-SNAPSHOT</version>
+    <version>5.4.3-A.2-SNAPSHOT</version>
     <name>Alfresco Transform Core</name>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Releasing 5.4.3-A.7,
because 5.4.3-A.6-SNAPSHOT is already present in nexus.

<img width="1456" height="114" alt="image" src="https://github.com/user-attachments/assets/1129bc86-11ca-4e0d-8d9e-5fcb863d16d6" />

