### PR TITLE
Potential fix for code scanning alert no. 1376: Uncontrolled command line

### DIFF
--- a/deprecated/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
+++ b/deprecated/alfresco-transformer-base/src/test/java/org/alfresco/transformer/AbstractMetadataExtractsIT.java
@@ -120,6 +120,11 @@ public abstract class AbstractMetadataExtractsIT
 
     private Map<String, Serializable> readExpectedMetadata(String filename, File actualMetadataFile) throws IOException
     {
+        // Reject path separators or parent-directory segments to keep the classpath lookup safe
+        if (filename.contains("..") || filename.contains("/") || filename.contains("\\"))
+        {
+            throw new IllegalArgumentException("Invalid expected metadata filename: " + filename);
+        }
         try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(filename))
         {
             if (inputStream == null)

--- a/engines/base/src/main/java/org/alfresco/transform/base/executors/RuntimeExec.java
+++ b/engines/base/src/main/java/org/alfresco/transform/base/executors/RuntimeExec.java
@@ -667,11 +667,7 @@ public class RuntimeExec
             {
                 String key = entry.getKey();
                 String value = entry.getValue() == null ? "" : entry.getValue();
-                if (value.contains("\n") || value.contains("\r") || value.contains("\0"))
-                {
-                    throw new IllegalArgumentException(
-                            "Command property '" + key + "' contains an illegal character");
-                }
+                validateCommandPropertyValue(key, value);
                 // progressively replace the property in the command
                 key = (VAR_OPEN + key + VAR_CLOSE);
                 int index = sb.indexOf(key);
@@ -702,6 +698,59 @@ public class RuntimeExec
         }
         // done
         return adjustedCommandElements.toArray(new String[0]);
+    }
+
+    private void validateCommandPropertyValue(String key, String value)
+    {
+        if (value.contains("\n") || value.contains("\r") || value.contains("\0"))
+        {
+            throw new IllegalArgumentException(
+                    "Command property '" + key + "' contains an illegal character");
+        }
+
+        if ("source".equals(key) || "target".equals(key))
+        {
+            validatePathProperty(key, value);
+        }
+        else if ("sourceMimetype".equals(key) || "targetMimetype".equals(key))
+        {
+            validateMimetypeProperty(key, value);
+        }
+    }
+
+    private void validatePathProperty(String key, String value)
+    {
+        if (value.isBlank())
+        {
+            throw new IllegalArgumentException("Command property '" + key + "' must not be blank");
+        }
+
+        if (value.indexOf('"') >= 0 || value.indexOf('\'') >= 0 || value.indexOf('`') >= 0)
+        {
+            throw new IllegalArgumentException(
+                    "Command property '" + key + "' contains an illegal character");
+        }
+
+        File file = new File(value);
+        if (!file.isAbsolute())
+        {
+            throw new IllegalArgumentException(
+                    "Command property '" + key + "' must be an absolute path");
+        }
+    }
+
+    private void validateMimetypeProperty(String key, String value)
+    {
+        if (value.isBlank())
+        {
+            throw new IllegalArgumentException("Command property '" + key + "' must not be blank");
+        }
+
+        if (!value.matches("^[a-zA-Z0-9!#$&^_.+-]+/[a-zA-Z0-9!#$&^_.+-]+$"))
+        {
+            throw new IllegalArgumentException(
+                    "Command property '" + key + "' is not a valid mimetype");
+        }
     }
 
     /**

--- a/engines/base/src/test/java/org/alfresco/transform/base/metadata/AbstractMetadataExtractsIT.java
+++ b/engines/base/src/test/java/org/alfresco/transform/base/metadata/AbstractMetadataExtractsIT.java
@@ -119,6 +119,11 @@ public abstract class AbstractMetadataExtractsIT
 
     private Map<String, Serializable> readExpectedMetadata(String filename, File actualMetadataFile) throws IOException
     {
+        // Reject path separators or parent-directory segments to keep the classpath lookup safe
+        if (filename.contains("..") || filename.contains("/") || filename.contains("\\"))
+        {
+            throw new IllegalArgumentException("Invalid expected metadata filename: " + filename);
+        }
         try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(filename))
         {
             if (inputStream == null)


### PR DESCRIPTION
Potential fix for [https://github.com/Alfresco/alfresco-transform-core/security/code-scanning/1376](https://github.com/Alfresco/alfresco-transform-core/security/code-scanning/1376)

Best fix: enforce a strict allowlist validation step in `RuntimeExec.getCommand(...)` for all externally supplied property values before they are substituted into command arguments.

Single best approach (minimal functional impact):
- **File:** `engines/base/src/main/java/org/alfresco/transform/base/executors/RuntimeExec.java`
- Add helper validation methods in `RuntimeExec`:
  - generic unsafe-character check for all properties
  - stricter validation for filesystem-path properties (`source`, `target`) to reject argument-breaking chars and require absolute paths
  - mimetype format validation for `sourceMimetype` / `targetMimetype`
- Invoke this validation inside `getCommand(...)` before `sb.replace(...)`.

This preserves existing command templates and behavior while blocking maliciously crafted values from influencing command execution unsafely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
