### PR TITLE
OPSEXP-4056 Update alfresco-pdf-renderer to 1.3.0-78

### DIFF
--- a/engines/aio/Dockerfile
+++ b/engines/aio/Dockerfile
@@ -21,7 +21,7 @@ ARG LIBREOFFICE_VERSION=7.2.5
 ENV LIBREOFFICE_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/org/libreoffice/libreoffice-dist/${LIBREOFFICE_VERSION}/libreoffice-dist-${LIBREOFFICE_VERSION}-linux.gz
 ENV LIBREOFFICE_ARM64_RPM_URL=https://dl.rockylinux.org/pub/rocky/9/devel/aarch64/os/Packages/l/
 ENV LIBREOFFICE_ARM64_RPM_VERSION=libreoffice-7.1.8.1
-ARG PDF_RENDERER_VERSION=1.3.0-76
+ARG PDF_RENDERER_VERSION=1.3.0-78
 ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux.tgz
 ENV ALFRESCO_PDF_RENDERER_ARM64_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux-arm.tgz
 

--- a/engines/pdfrenderer/Dockerfile
+++ b/engines/pdfrenderer/Dockerfile
@@ -6,7 +6,7 @@
 ARG JAVA_BASE_IMAGE=alfresco/alfresco-base-java:jre17-rockylinux9@sha256:f98833508b7be8c4b44a25450f9faac44cacfdc075f2295e02836b93fd05bb9c
 FROM ${JAVA_BASE_IMAGE}
 
-ARG PDF_RENDERER_VERSION=1.3.0-76
+ARG PDF_RENDERER_VERSION=1.3.0-78
 ENV ALFRESCO_PDF_RENDERER_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux.tgz
 ENV ALFRESCO_PDF_RENDERER_ARM64_LIB_RPM_URL=https://nexus.alfresco.com/nexus/service/local/repositories/releases/org/alfresco/alfresco-pdf-renderer/${PDF_RENDERER_VERSION}/alfresco-pdf-renderer-${PDF_RENDERER_VERSION}-linux-arm.tgz
 ENV JAVA_OPTS=""


### PR DESCRIPTION
OPSEXP-4056

Test newly built alfresco-pdf-renderer version.