### PR TITLE
[ACS-12260]: Add missing permission to minted token

### DIFF
--- a/.github/workflows/update-pdf-renderer.yml
+++ b/.github/workflows/update-pdf-renderer.yml
@@ -24,6 +24,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-members: read
           repositories: |
             alfresco-transform-core
             alfresco-pdf-renderer


### PR DESCRIPTION
## Fix: Add missing `repo` scope permission for team reviewer assignment

This PR addresses a missing permission that was overlooked in #1319.

### Problem
The `update-pdf-renderer` workflow was failing after successfully creating a PR because it lacked the necessary permissions to assign a team reviewer. The workflow would create the PR but then error out when attempting to request the `alfresco-dependency-maintainers` team for review:
\```
Error: Unable to request reviewers. If requesting team reviewers a 'repo' scoped PAT is required.
Error: Validation Failed: \"Could not resolve to a node with the global id of 'T_kwDOAAX3184BHlgu'.\"
\```
The failure was observed in [this build](https://github.com/Alfresco/alfresco-transform-core/actions/runs/30780690573/job/91584576301).
### Root Cause
The minted token used by the workflow was not granted the `repo` scope, which is required by the GitHub API when requesting team reviewers on a pull request.
### Fix
Added the missing `repo` scope permission to the token configuration so that the workflow can successfully assign the `alfresco-dependency-maintainers` team as reviewers after PR creation.
### Related
- Original PR: #1319
