### PR TITLE
ACS-12423 Please [release] 5.4.4-A.2 [skip tests] and bump spring-retry, log4j2

### DIFF
--- a/deprecated/alfresco-transformer-base/pom.xml
+++ b/deprecated/alfresco-transformer-base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.1-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/aio/pom.xml
+++ b/engines/aio/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/base/pom.xml
+++ b/engines/base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/example/pom.xml
+++ b/engines/example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/imagemagick/pom.xml
+++ b/engines/imagemagick/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/libreoffice/pom.xml
+++ b/engines/libreoffice/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/misc/pom.xml
+++ b/engines/misc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/pdfrenderer/pom.xml
+++ b/engines/pdfrenderer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/engines/tika/pom.xml
+++ b/engines/tika/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-transform-core</artifactId>
-        <version>5.4.5-A.4-SNAPSHOT</version>
+        <version>5.4.4-A.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-transform-core</artifactId>
-    <version>5.4.5-A.4-SNAPSHOT</version>
+    <version>5.4.4-A.2-SNAPSHOT</version>
     <name>Alfresco Transform Core</name>
     <packaging>pom</packaging>
 
@@ -40,7 +40,8 @@
 
         <parent.core.deploy.skip>false</parent.core.deploy.skip>
         <commons-lang3.version>3.18.0</commons-lang3.version>
-        <spring-retry.version>2.0.12</spring-retry.version>
+        <spring-retry.version>2.0.13</spring-retry.version>
+        <log4j2.version>2.26.1</log4j2.version> <!-- security fix CVE-2026-49844 -->
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <parent.core.deploy.skip>false</parent.core.deploy.skip>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <spring-retry.version>2.0.13</spring-retry.version>
-        <log4j2.version>2.26.1</log4j2.version> <!-- security fix CVE-2026-49844 -->
+        <log4j2.version>2.26.1</log4j2.version> <!-- security fix CVE-2026-49844, can be removed once Spring Boot manages log4j2 >= 2.26.1 -->
     </properties>
 
     <profiles>


### PR DESCRIPTION
bumped log4j2 to 2.26.1 and spring-retry to 2.0.13 to remediate known vulnerabilities and align transitive dependency resolution across modules.