### PR TITLE
ACS-12630: Fix Tomcat CVEs (CVE-2026-53434, CVE-2026-55276, CVE-2026-53404) — bump tomcat-embed to 11.0.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency.commons-io.version>2.20.0</dependency.commons-io.version>
         <dependency.imaging.version>1.0.0-alpha6</dependency.imaging.version>
         <dependency.snakeyaml.version>2.3</dependency.snakeyaml.version>
-        <dependency.tomcat.embed.version>11.0.22</dependency.tomcat.embed.version>
+        <dependency.tomcat.embed.version>11.0.23</dependency.tomcat.embed.version> <!-- CVE-2026-53434, CVE-2026-55276, CVE-2026-53404 -->
         <dependency.activemq-client.version>6.2.7</dependency.activemq-client.version>
 
         <spotless-plugin.version>2.45.0</spotless-plugin.version>


### PR DESCRIPTION
## Summary

Bumps the pinned Apache Tomcat Embedded version from `11.0.22` to `11.0.23` in the
root `pom.xml` to remediate three Tomcat security vulnerabilities.

Jira: ACS-12630

## CVEs addressed

| CVE | Severity | Description |
|-----|----------|-------------|
| [CVE-2026-53434](https://nvd.nist.gov/vuln/detail/CVE-2026-53434) | Critical (9.1) | Error condition not handled when configuring CRLs for the FFM-based connector — potential certificate revocation bypass |
| [CVE-2026-55276](https://nvd.nist.gov/vuln/detail/CVE-2026-55276) | Critical (9.1) | Incorrect control flow: special roles & empty auth constraints silently dropped from the effective `web.xml` |
| [CVE-2026-53404](https://nvd.nist.gov/vuln/detail/CVE-2026-53404) | High (7.3) | Incorrect control flow in the rewrite valve — first match in an OR chain skipped subsequent non-OR conditions |

All three are fixed in Apache Tomcat **11.0.23**.

## Changes

- `pom.xml`: `dependency.tomcat.embed.version` `11.0.22` → `11.0.23`

This single property drives the managed `tomcat-embed-core`, `tomcat-embed-el`, and
`tomcat-embed-websocket` dependencies, so the fix applies to **all** T-Engines
(`base`, `imagemagick`, `libreoffice`, `misc`, `pdfrenderer`, `tika`, `aio`, `example`)
and the `deprecated/alfresco-transformer-base` module (which inherits the managed version).

## Impact / compatibility

- Patch-level bump within the Tomcat `11.0.x` line managed by Spring Boot 4.0.7 — no API/behaviour changes expected.
- No source changes; dependency-only update.
- No remaining references to `11.0.22` in the repo.

## Testing

- [x] `mvn clean test-compile` passes
- [x] CVE re-scan confirms `tomcat-embed 11.0.23` is clean of all three CVEs

## Notes for reviewers / downstream repos

- The `alfresco-transform-model` jar does **not** bundle Tomcat, so consumers of that
  artifact do not inherit this fix.
- Downstream Spring Boot services (e.g. **alfresco-transform-router / T-Router**) carry
  their own `tomcat-embed` dependency and must be patched separately.
- This override can be removed once the Spring Boot BOM manages `tomcat-embed >= 11.0.23`.