### PR TITLE
ACS-12551: Alpha Release 5.4.4-A.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ env:
   # Both variables are required to be set before the release process starts.
   # As the release is triggered by a commit message with "[release]" keyword on a release branch,
   # setting these variables to new values can be done in the same commit and will indicate the release and the dev versions in it.
-  RELEASE_VERSION: "5.4.4-A.5" # The version of the release (tag).
-  DEVELOPMENT_VERSION: "5.4.4-A.6-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
+  RELEASE_VERSION: "5.4.4-A.6" # The version of the release (tag).
+  DEVELOPMENT_VERSION: "5.4.4-A.7-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
 
 permissions:
   contents: read

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency.commons-io.version>2.20.0</dependency.commons-io.version>
         <dependency.imaging.version>1.0.0-alpha6</dependency.imaging.version>
         <dependency.snakeyaml.version>2.3</dependency.snakeyaml.version>
-        <dependency.tomcat.embed.version>11.0.23</dependency.tomcat.embed.version> <!-- CVE-2026-53434, CVE-2026-55276, CVE-2026-53404 -->
+        <dependency.tomcat.embed.version>11.0.23</dependency.tomcat.embed.version>
         <dependency.activemq-client.version>6.2.7</dependency.activemq-client.version>
 
         <spotless-plugin.version>2.45.0</spotless-plugin.version>


### PR DESCRIPTION
### Purpose

Prepare the `5.4.4-A.6` release of Alfresco Transform Core and bump the development version to the next snapshot.

### Changes

- **`.github/workflows/ci.yml`** — Update release/dev version markers to drive the release process:
  - `RELEASE_VERSION`: `5.4.4-A.5` → `5.4.4-A.6`
  - `DEVELOPMENT_VERSION`: `5.4.4-A.6-SNAPSHOT` → `5.4.4-A.7-SNAPSHOT`
- **`pom.xml`** — Remove the stale CVE comment (`CVE-2026-53434, CVE-2026-55276, CVE-2026-53404`) from the `dependency.tomcat.embed.version` property. The Tomcat embed version remains unchanged at `11.0.23`.

### Notes

- No functional code changes; this is a release-preparation PR.
- Per the CI convention, the version variables are set in the same commit that triggers the release (via the `[release]` keyword on a release branch).