### PR TITLE
[ACS-12630]: Please [release] 5.4.4-A.6 [skip tests]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ env:
   # Both variables are required to be set before the release process starts.
   # As the release is triggered by a commit message with "[release]" keyword on a release branch,
   # setting these variables to new values can be done in the same commit and will indicate the release and the dev versions in it.
-  RELEASE_VERSION: "5.4.4-A.5" # The version of the release (tag).
-  DEVELOPMENT_VERSION: "5.4.4-A.6-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
+  RELEASE_VERSION: "5.4.4-A.6" # The version of the release (tag).
+  DEVELOPMENT_VERSION: "5.4.4-A.7-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
 
 permissions:
   contents: read

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency.commons-io.version>2.20.0</dependency.commons-io.version>
         <dependency.imaging.version>1.0.0-alpha6</dependency.imaging.version>
         <dependency.snakeyaml.version>2.3</dependency.snakeyaml.version>
-        <dependency.tomcat.embed.version>11.0.23</dependency.tomcat.embed.version> <!-- CVE-2026-53434, CVE-2026-55276, CVE-2026-53404 -->
+        <dependency.tomcat.embed.version>11.0.23</dependency.tomcat.embed.version>
         <dependency.activemq-client.version>6.2.7</dependency.activemq-client.version>
 
         <spotless-plugin.version>2.45.0</spotless-plugin.version>


### PR DESCRIPTION
## Prepare release 5.4.4-A.6

### Summary
Bumps the release/development versions in the CI workflow to prepare the `5.4.4-A.6` release, and tidies up a stale CVE comment in the root `pom.xml`.

### Changes
- **`.github/workflows/ci.yml`**
  - `RELEASE_VERSION`: `5.4.4-A.5` → `5.4.4-A.6` (the tag to be released).
  - `DEVELOPMENT_VERSION`: `5.4.4-A.6-SNAPSHOT` → `5.4.4-A.7-SNAPSHOT` (next dev version set in poms after release).
- **`pom.xml`**
  - Removed the trailing CVE comment (`CVE-2026-53434, CVE-2026-55276, CVE-2026-53404`) from `dependency.tomcat.embed.version`. The pinned version (`11.0.23`) is unchanged.

### Notes
- No functional/code changes; this is a release-preparation change.
- Per repo conventions, the release is triggered by a commit message containing the `[release]` keyword on a release branch, and both version variables are updated in the same commit.