### PR TITLE
ACS-12750 : Please [release] GA 5.4.4 [skip tests]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ env:
   # Both variables are required to be set before the release process starts.
   # As the release is triggered by a commit message with "[release]" keyword on a release branch,
   # setting these variables to new values can be done in the same commit and will indicate the release and the dev versions in it.
-  RELEASE_VERSION: "5.4.4-A.6" # The version of the release (tag).
-  DEVELOPMENT_VERSION: "5.4.4-A.7-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
+  RELEASE_VERSION: "5.4.4" # The version of the release (tag).
+  DEVELOPMENT_VERSION: "5.4.5-A.1-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
 
 permissions:
   contents: read


### PR DESCRIPTION
# Release GA 5.4.4 [ACS-12750]

## Summary
This PR prepares the **GA (General Availability) release of version 5.4.4** for `alfresco-transform-core`. It updates the release automation configuration to promote the project from the pre-release alpha builds (`5.4.4-A.x`) to the final GA version, and sets the next development iteration.

## Changes
Updated the release version variables in `.github/workflows/ci.yml`:

| Variable | Before | After |
|----------|--------|-------|
| `RELEASE_VERSION` | `5.4.4-A.6` | `5.4.4` |
| `DEVELOPMENT_VERSION` | `5.4.4-A.7-SNAPSHOT` | `5.4.5-A.1-SNAPSHOT` |

```diff name=.github/workflows/ci.yml
-  RELEASE_VERSION: "5.4.4-A.6" # The version of the release (tag).
-  DEVELOPMENT_VERSION: "5.4.4-A.7-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
+  RELEASE_VERSION: "5.4.4" # The version of the release (tag).
+  DEVELOPMENT_VERSION: "5.4.5-A.1-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
```

## Details
- **`RELEASE_VERSION`** is set to `5.4.4` — this is the final GA tag that will be created when the release process runs.
- **`DEVELOPMENT_VERSION`** is set to `5.4.5-A.1-SNAPSHOT` — this is the version that will be written to the POM files after the release, so ongoing development continues on the next iteration.

## How it works
The release is triggered by a commit message containing the `[release]` keyword on a release branch. Both variables must be set before the release process starts, which this PR handles.

## JIRA
- **ACS-12750** — Release GA 5.4.4

## Testing
- [ ] Verify the release pipeline picks up `5.4.4` as the tag.
- [ ] Confirm POM files are bumped to `5.4.5-A.1-SNAPSHOT` after the release completes.